### PR TITLE
Allow reimport of the same edl.

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -7,6 +7,8 @@
 #include "parser.h"
 #include "utils.h"
 
+// This is a change in anakrish fork.
+
 static bool _is_file(const std::string& path)
 {
     FILE* f = fopen(path.c_str(), "r");

--- a/parser.h
+++ b/parser.h
@@ -4,6 +4,7 @@
 #ifndef PARSER_H
 #define PARSER_H
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -14,6 +15,7 @@
 class Parser
 {
     static std::vector<std::string> stack_;
+    static std::map<std::string, Edl*> cache_;
 
     std::string filename_;
     std::string basename_;
@@ -57,6 +59,9 @@ class Parser
     Dims* parse_dims();
 
   private:
+    void append_include(const std::string& inc);
+    void append_type(UserType* type);
+    void append_function(std::vector<Function*>& funcs, Function* f);
     void warn_allow_list(const std::string& fname);
     void warn_non_portable(Function* f);
     void error_size_count(Function* f);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(basic)
 add_subdirectory(behavior)
 add_subdirectory(cmdline)
 add_subdirectory(comprehensive)
+add_subdirectory(import)
 
 # Virtual Mode execution for tests.
 add_subdirectory(virtual)

--- a/test/behavior/CMakeLists.txt
+++ b/test/behavior/CMakeLists.txt
@@ -85,3 +85,4 @@ add_behavior_test(
   deepcopy_value.edl
   "error: the structure declaration \"MyStruct\" specifies a deep copy is expected. Referenced by value in function \"deepcopy_value\" detected."
   "")
+

--- a/test/import/CMakeLists.txt
+++ b/test/import/CMakeLists.txt
@@ -1,0 +1,73 @@
+# Copyright (c) Open Enclave SDK contributors. Licensed under the MIT License.
+
+function(add_import_test test_name edl pass_re fail_re)
+  add_test(NAME ${test_name} COMMAND oeedger8r --header-only --search-path
+                                     ${CMAKE_CURRENT_SOURCE_DIR} ${edl})
+  if(${fail_re})
+    set_tests_properties(
+      ${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "${pass_re}"
+                              FAIL_REGULAR_EXPRESSION "${fail_re}")
+  else()
+    set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION
+                                                 "${pass_re}")
+  endif()
+endfunction()
+
+# Test selective import of items from a.edl.
+add_import_test(oeedger8r_selective_import1 b0.edl "Success." "")
+
+# Test multiple import of a.edl
+add_import_test(oeedger8r_multiple_import1 b1.edl "Success." "")
+
+# Defining an ecall with same name as imported ecall should fail.
+add_import_test(
+  oeedger8r_import_ecall_redefinition_error1 b2.edl
+  "Duplicate function definition detected for a_ecall1" "Success.")
+
+# Defining an ecall with same name as imported ocall should fail.
+add_import_test(
+  oeedger8r_import_ecall_redefinition_error2 b3.edl
+  "Duplicate function definition detected for a_ecall1" "Success.")
+
+# Defining an ocall with same name as imported ocall should fail.
+add_import_test(
+  oeedger8r_import_ocall_redefinition_error1 b4.edl
+  "Duplicate function definition detected for a_ocall1" "Success.")
+
+# Defining an ocall with same name as imported ecall should fail.
+add_import_test(
+  oeedger8r_import_ocall_redefinition_error2 b5.edl
+  "Duplicate function definition detected for a_ocall1" "Success.")
+
+# Defining an enum with same name as imported type should fail.
+add_import_test(oeedger8r_import_type_redefinition_error1 b6.edl
+                "Duplicate type definition detected for a_struct1" "Success.")
+
+# Defining an struct with same name as imported type should fail.
+add_import_test(oeedger8r_import_type_redefinition_error2_error b7.edl
+                "Duplicate type definition detected for a_struct1" "Success.")
+
+# Importing a file with duplicate type definitions should error.
+add_import_test(oeedger8r_import_duplicate_type_definitions_error b8.edl
+                "Duplicate type definition detected for a_struct1" "Success.")
+
+# Importing a file with duplicate ecalls should error.
+add_import_test(
+  oeedger8r_import_duplicate_ecall_definitions_error b9.edl
+  "Duplicate function definition detected for a_ecall1" "Success.")
+
+# Importing a file with duplicate ocalls should error.
+add_import_test(
+  oeedger8r_import_duplicate_ocall_definitions_error b10.edl
+  "Duplicate function definition detected for a_ocall1" "Success.")
+
+# Importing a file with same name ocall and ecall should error.
+add_import_test(oeedger8r_import_same_name_ocall_ecall_error b11.edl
+                "Duplicate function definition detected for foo" "Success.")
+
+# Importing same function via a diamong import should succeed.
+add_import_test(oeedger8r_import_diamond diamond_d.edl "Success." "Duplicate")
+
+# Importing an edl with same basename is allowed.
+add_import_test(oeedger8r_import_same_basename samename.edl "Success."
+                "Recursive")

--- a/test/import/a1.edl
+++ b/test/import/a1.edl
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  struct a_struct1 {
+    int x;
+  };
+
+  struct a_struct2 {
+    int x;
+  };
+  
+
+  trusted {
+    public void a_ecall1(void);
+    public void a_ecall2(void);    
+  };
+  untrusted {
+    void a_ocall1(void);
+    void a_ocall2(void);    
+  };
+};

--- a/test/import/a1_nest.edl
+++ b/test/import/a1_nest.edl
@@ -1,0 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a1.edl" import *;
+};

--- a/test/import/a2.edl
+++ b/test/import/a2.edl
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  struct a_struct1 {
+    int x;
+  };
+
+  struct a_struct1 {
+    int x;
+  };
+  
+
+  trusted {
+    public void a_ecall1(void);
+    public void a_ecall2(void);    
+  };
+  untrusted {
+    void a_ocall1(void);
+    void a_ocall2(void);    
+  };
+};

--- a/test/import/a3.edl
+++ b/test/import/a3.edl
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  struct a_struct1 {
+    int x;
+  };
+
+  struct a_struct2 {
+    int x;
+  };
+  
+
+  trusted {
+    public void a_ecall1(void);
+    public void a_ecall1(void);    
+  };
+  untrusted {
+    void a_ocall1(void);
+    void a_ocall2(void);    
+  };
+};

--- a/test/import/a4.edl
+++ b/test/import/a4.edl
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  struct a_struct1 {
+    int x;
+  };
+
+  struct a_struct2 {
+    int x;
+  };
+  
+
+  trusted {
+    public void a_ecall1(void);
+    public void a_ecall2(void);    
+  };
+  untrusted {
+    void a_ocall1(void);
+    void a_ocall1(void);    
+  };
+};

--- a/test/import/a5.edl
+++ b/test/import/a5.edl
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  struct a_struct1 {
+    int x;
+  };
+
+  struct a_struct2 {
+    int x;
+  };
+  
+
+  trusted {
+    public void foo(void);
+    public void a_ecall2(void);    
+  };
+  untrusted {
+    void foo(void);
+    void a_ecall2(void);    
+  };
+};

--- a/test/import/b0.edl
+++ b/test/import/b0.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  // Import specific items.
+  from "a1_nest.edl" import a_ecall1, a_ocall1;
+
+  // Define items with same name as unimported items in a.edl.
+  trusted {
+    public void a_ecall2(void);
+  };
+
+  untrusted {
+    void a_ocall2(void);
+  };
+};

--- a/test/import/b1.edl
+++ b/test/import/b1.edl
@@ -1,0 +1,20 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  // Import multiple times.
+  from "a1_nest.edl" import *;
+  from "a1.edl" import *;
+
+  // Import whole file.
+  import "a1_nest.edl"
+  import "a1.edl"
+
+  // Import specific functions.
+  from "a1_nest.edl" import a_ecall1, a_ocall1;
+  from "a1.edl" import a_ecall1, a_ocall1;
+
+  trusted {
+    public void b_ecall(void);
+  };
+};

--- a/test/import/b10.edl
+++ b/test/import/b10.edl
@@ -1,0 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a4.edl" import *;
+};

--- a/test/import/b11.edl
+++ b/test/import/b11.edl
@@ -1,0 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a5.edl" import *;
+};

--- a/test/import/b2.edl
+++ b/test/import/b2.edl
@@ -1,0 +1,10 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a1_nest.edl" import *;
+
+  trusted {
+    public void a_ecall1(void);
+  };
+};

--- a/test/import/b3.edl
+++ b/test/import/b3.edl
@@ -1,0 +1,14 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a1_nest.edl" import *;
+
+  untrusted {
+    void a_ecall1(void);
+  };
+
+  trusted {
+    public void unused();
+  };
+};

--- a/test/import/b4.edl
+++ b/test/import/b4.edl
@@ -1,0 +1,10 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a1_nest.edl" import *;
+
+  untrusted {
+    void a_ocall1(void);
+  };
+};

--- a/test/import/b5.edl
+++ b/test/import/b5.edl
@@ -1,0 +1,10 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a1_nest.edl" import *;
+
+  trusted {
+    public void a_ocall1(void);
+  };
+};

--- a/test/import/b6.edl
+++ b/test/import/b6.edl
@@ -1,0 +1,11 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a1_nest.edl" import *;
+
+  enum a_struct1 {
+    X = 5
+  };
+};
+

--- a/test/import/b7.edl
+++ b/test/import/b7.edl
@@ -1,0 +1,10 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a1_nest.edl" import *;
+
+  struct a_struct1 {
+    int x;
+  };
+};

--- a/test/import/b8.edl
+++ b/test/import/b8.edl
@@ -1,0 +1,7 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a2.edl" import *;
+};
+

--- a/test/import/b9.edl
+++ b/test/import/b9.edl
@@ -1,0 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a3.edl" import *;
+};

--- a/test/import/diamond_b.edl
+++ b/test/import/diamond_b.edl
@@ -1,0 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a1_nest.edl" import a_ecall1;
+};

--- a/test/import/diamond_c.edl
+++ b/test/import/diamond_c.edl
@@ -1,0 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  from "a1_nest.edl" import a_ecall1;
+};

--- a/test/import/diamond_d.edl
+++ b/test/import/diamond_d.edl
@@ -1,0 +1,11 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  // Import a1_ecall via  b and c.
+  import "diamond_b.edl"
+  import "diamond_c.edl"
+  
+  // Import a2_ecall directly.
+  from "a1_nest.edl" import a_ecall2;
+};

--- a/test/import/dir1/samename.edl
+++ b/test/import/dir1/samename.edl
@@ -1,0 +1,15 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave
+{
+   trusted
+   {
+      public int sample_ecall0();
+   };
+
+   untrusted
+   {
+      int sample_ocall0();
+   };
+};

--- a/test/import/samename.edl
+++ b/test/import/samename.edl
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave
+{
+   from "dir1/samename.edl" import *;
+
+   trusted
+   {
+      public int sample_ecall();
+   };
+
+   untrusted
+   {
+      int sample_ocall();
+   };
+};


### PR DESCRIPTION
EDL language allows reimporting the same edl or items multiple times:

  from "a.edl" import *;
  from "a.edl" import *;
  import "a.edl"
  from "a.edl" import a_ecall1;

The above is valid in edl. EDL behaves as if a '#pragma once' is applied
to each imported item within an EDL - both types and functions.

To accomplish this:
- When ever an EDL is parsed, the Edl object is cached.
- Next time the same edl is imported, the cached Edl object is returned.
  This ensures that only one Function object exists for a function with
  a given name in an EDL.
- When a function is imported, pointer comparision can be used to check
  if the function has already been imported. If so, then it is not an error.
  Otherwise if another function exists with the same name, an error is
  raised.

Locked down interesting import scenarios with tests.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>