### PR TITLE
Add C preprocessor suport to oeedger8r

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.1)
 project(oeedger8r)
 
 set(CMAKE_CXX_STANDARD 11)
-add_executable(oeedger8r main.cpp parser.cpp lexer.cpp)
+add_executable(oeedger8r main.cpp parser.cpp lexer.cpp preprocessor.cpp)
 set_property(TARGET oeedger8r PROPERTY POSITION_INDEPENDENT_CODE on)
 
 enable_testing()

--- a/main.cpp
+++ b/main.cpp
@@ -54,6 +54,7 @@ int main(int argc, char** argv)
     std::string untrusted_dir = ".";
     std::string trusted_dir = ".";
     std::vector<std::string> files;
+    std::vector<std::string> defines;
     int i = 1;
 
     if (argc == 1)
@@ -91,6 +92,8 @@ int main(int argc, char** argv)
             untrusted_dir = get_dir(i++);
         else if (a == "--experimental")
             ;
+        else if (a.rfind("-D", 0) == 0)
+            defines.push_back(a);
         else if (a == "--help")
         {
             printf("%s\n", usage);
@@ -127,7 +130,7 @@ int main(int argc, char** argv)
 
     for (std::string& file : files)
     {
-        Parser p(file, searchpaths);
+        Parser p(file, searchpaths, defines);
         Edl* edl = p.parse();
 
         if (gen_trusted)

--- a/parser.h
+++ b/parser.h
@@ -18,6 +18,7 @@ class Parser
     std::string filename_;
     std::string basename_;
     std::vector<std::string> searchpaths_;
+    std::vector<std::string> defines_;
 
     Lexer* lex_;
     Token t_;
@@ -74,7 +75,8 @@ class Parser
   public:
     Parser(
         const std::string& filename,
-        const std::vector<std::string>& searchpaths);
+        const std::vector<std::string>& searchpaths,
+        const std::vector<std::string>& defines);
     ~Parser();
 
     Edl* parse();

--- a/preprocessor.cpp
+++ b/preprocessor.cpp
@@ -1,0 +1,55 @@
+#include "preprocessor.h"
+#include "utils.h"
+
+#ifdef _WIN32
+#define CPP_CMD "cl.exe /EP /nologo"
+#else
+#define CPP_CMD "cpp -P"
+#endif
+
+Preprocessor::Preprocessor(
+    std::vector<std::string>& defines)
+{
+    _defines = defines;
+}
+
+/*
+ * Outputs a command in the following format:
+ * CPP_CMD {defines...} {input_edl} > {output_file}
+ */
+std::string Preprocessor::get_cpp_cmd(
+    const std::string& src,
+    const std::string& dest)
+{
+    std::ostringstream oss;
+    oss << CPP_CMD;
+    for (const auto& d : _defines)
+        oss << " " << d;
+
+    oss << " " << src << " > " << dest;
+    return oss.str();
+}
+
+std::string Preprocessor::process(
+    const std::string& file,
+    const std::string& basename)
+{
+    std::string out_file(basename + ".edl.out");
+    std::string cmd = get_cpp_cmd(file, out_file);
+
+    if (system(cmd.c_str()) != 0)
+    {
+        /*
+         * The preprocessor dependency is a soft one. If the preprocessor
+         * command fails for any reason, just output and error message
+         * and move on with the original file.
+         *
+         * If the file really did depend on the preprocessor, it will contain
+         * invalid characters and parsing will fail later.
+         */
+        printf("warning: preprocessing file %s\n", file.c_str());
+        return file;
+    }
+
+    return out_file;
+}

--- a/preprocessor.h
+++ b/preprocessor.h
@@ -1,0 +1,22 @@
+#ifndef PREPROCESSOR_H
+#define PREPROCESSOR_H
+
+#include <string>
+#include <vector>
+
+class Preprocessor
+{
+public:
+    Preprocessor(std::vector<std::string>& defines);
+
+    std::string process(
+        const std::string& file,
+        const std::string& basename);
+
+private:
+    std::string get_cpp_cmd(const std::string& src, const std::string& dest);
+
+    std::vector<std::string> _defines;
+};
+
+#endif // PREPROCESSOR_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(basic)
 add_subdirectory(behavior)
 add_subdirectory(cmdline)
 add_subdirectory(comprehensive)
+add_subdirectory(preprocessor)
 
 # Virtual Mode execution for tests.
 add_subdirectory(virtual)

--- a/test/preprocessor/CMakeLists.txt
+++ b/test/preprocessor/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_custom_command(
+  OUTPUT preprocessor_args.h preprocessor_t.h preprocessor_t.c
+  COMMAND oeedger8r -DTEST --trusted ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor.edl)
+
+add_custom_target(
+  build_preprocessor_test ALL
+  DEPENDS preprocessor_args.h preprocessor_t.h preprocessor_t.c)
+
+# TODO: If the test builds that means at least the preprocessor ran
+# and removed the directives. It does not mean that the proper defines
+# were passed though. Need to find a way to test this.
+

--- a/test/preprocessor/preprocessor.edl
+++ b/test/preprocessor/preprocessor.edl
@@ -1,0 +1,13 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted
+  {
+#ifdef TEST
+    public void first_ecall();
+#else
+    public void second_ecall();
+#endif
+  };
+};


### PR DESCRIPTION
Allow use of simple C preprocessor directives such as `#ifndef` and `#if`. Support this by invoking cl.exe on Windows and cpp on Linux.

This PR has a couple issues as-is:
1. The testing is not complete. I'll try to add a test that greps the generated code for the correct ecalls.
2. cl.exe/cpp must be in the developer's path when running oeedger8r. Is that ok?