### PR TITLE
Display full path to each processed file.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv)
             printf("%s\n", usage);
             exit(1);
         }
-        return fix_path_seperators(argv[i]);
+        return fix_path_separators(argv[i]);
     };
 
     while (i < argc)
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
             return 1;
         }
         else
-            files.push_back(fix_path_seperators(a));
+            files.push_back(fix_path_separators(a));
     }
 
     if (files.empty())

--- a/parser.cpp
+++ b/parser.cpp
@@ -48,7 +48,7 @@ Parser::Parser(
     {
         for (auto&& sp : searchpaths_)
         {
-            f = sp + path_sep() + filename_;
+            f = fix_path_separators(sp + path_sep() + filename_);
             if (_is_file(f))
                 break;
         }
@@ -77,6 +77,9 @@ Parser::Parser(
 
     t_ = lex_->next();
     t1_ = lex_->next();
+
+    // Remember full path to file.
+    filename_ = f;
 }
 
 Parser::~Parser()
@@ -145,6 +148,7 @@ Edl* Parser::parse()
     if (cache_.count(filename_))
         return cache_[filename_];
 
+    printf("Processing %s.\n", filename_.c_str());
     stack_.push_back(filename_);
     expect("enclave");
     expect("{");

--- a/test/import/CMakeLists.txt
+++ b/test/import/CMakeLists.txt
@@ -71,3 +71,39 @@ add_import_test(oeedger8r_import_diamond diamond_d.edl "Success." "Duplicate")
 # Importing an edl with same basename is allowed.
 add_import_test(oeedger8r_import_same_basename samename.edl "Success."
                 "Recursive")
+
+# Ensure that a.edl is picked up from first search-path. Warning will be raised
+# for function import_dir1_ecall.
+add_test(
+  NAME oeedger8r_import_search_path_order1
+  COMMAND oeedger8r a.edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/import_dir1
+          --search-path ${CMAKE_CURRENT_SOURCE_DIR}/import_dir2)
+set_tests_properties(
+  oeedger8r_import_search_path_order1
+  PROPERTIES PASS_REGULAR_EXPRESSION "Warning: Function 'import_dir1_ecall'")
+
+# Ensure that a.edl is picked up from first search-path. Warning will be raised
+# for function import_dir2_ecall.
+add_test(
+  NAME oeedger8r_import_search_path_order2
+  COMMAND oeedger8r a.edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/import_dir2
+          --search-path ${CMAKE_CURRENT_SOURCE_DIR}/import_dir1)
+set_tests_properties(
+  oeedger8r_import_search_path_order2
+  PROPERTIES PASS_REGULAR_EXPRESSION "Warning: Function 'import_dir2_ecall'")
+
+# Lockdown printing of imported file being processed.
+add_test(
+  NAME oeedger8r_import_print_processing
+  COMMAND oeedger8r processing.edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}
+          --search-path ${CMAKE_CURRENT_SOURCE_DIR}/import_dir3/x)
+
+file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/import_dir3/x/y/z.edl"
+     IMPORTED_FILE_PATH)
+# \ character becomes \\\\ in a regular expression.
+# Convert \ to \\ in IMPORTED_FILE_PATH.
+string(REGEX REPLACE "\\\\" "\\\\\\\\" IMPORTED_FILE_PATH ${IMPORTED_FILE_PATH})
+
+set_tests_properties(
+  oeedger8r_import_print_processing
+  PROPERTIES PASS_REGULAR_EXPRESSION "Processing ${IMPORTED_FILE_PATH}.")

--- a/test/import/import_dir1/a.edl
+++ b/test/import/import_dir1/a.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    // Use wchar_t so that a warning is raised with function name.
+    public void import_dir1_ecall([wstring, in] wchar_t* str);
+  };
+};

--- a/test/import/import_dir2/a.edl
+++ b/test/import/import_dir2/a.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    // Use wchar_t so that a warning is raised with function name.
+    public void import_dir2_ecall([wstring, in] wchar_t* str);
+  };
+};

--- a/test/import/import_dir3/x/y/z.edl
+++ b/test/import/import_dir3/x/y/z.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    public void z_ecall1(void);
+  };
+};

--- a/test/import/processing.edl
+++ b/test/import/processing.edl
@@ -1,0 +1,6 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+   import "y/z.edl"
+};

--- a/utils.h
+++ b/utils.h
@@ -327,7 +327,7 @@ inline const char* path_sep()
 #endif
 }
 
-inline std::string fix_path_seperators(const std::string& path)
+inline std::string fix_path_separators(const std::string& path)
 {
 #if _WIN32
     return replace(path, "/", "\\");


### PR DESCRIPTION
Displaying full path allows the user to figure out what file is being processed
in case an unintended file is being picked up from the specified search paths.
Add test for printed path.

Add tests to lock down the order in which search paths are processed.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>