### PR TITLE
Enable code coverage metrics for oeedger8r

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,0 +1,280 @@
+{
+  "_help_parse": "Options affecting listfile parsing",
+  "parse": {
+    "_help_additional_commands": [
+      "Specify structure for custom cmake functions"
+    ],
+    "additional_commands": {
+      "foo": {
+        "flags": [
+          "BAR",
+          "BAZ"
+        ],
+        "kwargs": {
+          "HEADERS": "*",
+          "SOURCES": "*",
+          "DEPENDS": "*"
+        }
+      }
+    },
+    "_help_vartags": [
+      "Specify variable tags."
+    ],
+    "vartags": [],
+    "_help_proptags": [
+      "Specify property tags."
+    ],
+    "proptags": []
+  },
+  "_help_format": "Options affecting formatting.",
+  "format": {
+    "_help_line_width": [
+      "How wide to allow formatted cmake files"
+    ],
+    "line_width": 80,
+    "_help_tab_size": [
+      "How many spaces to tab for indent"
+    ],
+    "tab_size": 2,
+    "_help_max_subgroups_hwrap": [
+      "If an argument group contains more than this many sub-groups",
+      "(parg or kwarg groups) then force it to a vertical layout."
+    ],
+    "max_subgroups_hwrap": 2,
+    "_help_max_pargs_hwrap": [
+      "If a positional argument group contains more than this many",
+      "arguments, then force it to a vertical layout."
+    ],
+    "max_pargs_hwrap": 6,
+    "_help_max_rows_cmdline": [
+      "If a cmdline positional group consumes more than this many",
+      "lines without nesting, then invalidate the layout (and nest)"
+    ],
+    "max_rows_cmdline": 2,
+    "_help_separate_ctrl_name_with_space": [
+      "If true, separate flow control names from their parentheses",
+      "with a space"
+    ],
+    "separate_ctrl_name_with_space": true,
+    "_help_separate_fn_name_with_space": [
+      "If true, separate function names from parentheses with a",
+      "space"
+    ],
+    "separate_fn_name_with_space": false,
+    "_help_dangle_parens": [
+      "If a statement is wrapped to more than one line, than dangle",
+      "the closing parenthesis on its own line."
+    ],
+    "dangle_parens": false,
+    "_help_dangle_align": [
+      "If the trailing parenthesis must be 'dangled' on its on",
+      "line, then align it to this reference: `prefix`: the start",
+      "of the statement,  `prefix-indent`: the start of the",
+      "statement, plus one indentation  level, `child`: align to",
+      "the column of the arguments"
+    ],
+    "dangle_align": "prefix",
+    "_help_min_prefix_chars": [
+      "If the statement spelling length (including space and",
+      "parenthesis) is smaller than this amount, then force reject",
+      "nested layouts."
+    ],
+    "min_prefix_chars": 4,
+    "_help_max_prefix_chars": [
+      "If the statement spelling length (including space and",
+      "parenthesis) is larger than the tab width by more than this",
+      "amount, then force reject un-nested layouts."
+    ],
+    "max_prefix_chars": 10,
+    "_help_max_lines_hwrap": [
+      "If a candidate layout is wrapped horizontally but it exceeds",
+      "this many lines, then reject the layout."
+    ],
+    "max_lines_hwrap": 2,
+    "_help_line_ending": [
+      "What style line endings to use in the output."
+    ],
+    "line_ending": "auto",
+    "_help_command_case": [
+      "Format command names consistently as 'lower' or 'upper' case"
+    ],
+    "command_case": "canonical",
+    "_help_keyword_case": [
+      "Format keywords consistently as 'lower' or 'upper' case"
+    ],
+    "keyword_case": "unchanged",
+    "_help_always_wrap": [
+      "A list of command names which should always be wrapped"
+    ],
+    "always_wrap": [],
+    "_help_enable_sort": [
+      "If true, the argument lists which are known to be sortable",
+      "will be sorted lexicographicall"
+    ],
+    "enable_sort": true,
+    "_help_autosort": [
+      "If true, the parsers may infer whether or not an argument",
+      "list is sortable (without annotation)."
+    ],
+    "autosort": false,
+    "_help_require_valid_layout": [
+      "By default, if cmake-format cannot successfully fit",
+      "everything into the desired linewidth it will apply the",
+      "last, most agressive attempt that it made. If this flag is",
+      "True, however, cmake-format will print error, exit with non-",
+      "zero status code, and write-out nothing"
+    ],
+    "require_valid_layout": false,
+    "_help_layout_passes": [
+      "A dictionary mapping layout nodes to a list of wrap",
+      "decisions. See the documentation for more information."
+    ],
+    "layout_passes": {}
+  },
+  "_help_markup": "Options affecting comment reflow and formatting.",
+  "markup": {
+    "_help_bullet_char": [
+      "What character to use for bulleted lists"
+    ],
+    "bullet_char": "*",
+    "_help_enum_char": [
+      "What character to use as punctuation after numerals in an",
+      "enumerated list"
+    ],
+    "enum_char": ".",
+    "_help_first_comment_is_literal": [
+      "If comment markup is enabled, don't reflow the first comment",
+      "block in each listfile. Use this to preserve formatting of",
+      "your copyright/license statements."
+    ],
+    "first_comment_is_literal": true,
+    "_help_literal_comment_pattern": [
+      "If comment markup is enabled, don't reflow any comment block",
+      "which matches this (regex) pattern. Default is `None`",
+      "(disabled)."
+    ],
+    "literal_comment_pattern": null,
+    "_help_fence_pattern": [
+      "Regular expression to match preformat fences in comments",
+      "default= ``r'^\\s*([`~]{3}[`~]*)(.*)$'``"
+    ],
+    "fence_pattern": "^\\s*([`~]{3}[`~]*)(.*)$",
+    "_help_ruler_pattern": [
+      "Regular expression to match rulers in comments default=",
+      "``r'^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$'``"
+    ],
+    "ruler_pattern": "^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$",
+    "_help_explicit_trailing_pattern": [
+      "If a comment line matches starts with this pattern then it",
+      "is explicitly a trailing comment for the preceeding",
+      "argument. Default is '#<'"
+    ],
+    "explicit_trailing_pattern": "#<",
+    "_help_hashruler_min_length": [
+      "If a comment line starts with at least this many consecutive",
+      "hash characters, then don't lstrip() them off. This allows",
+      "for lazy hash rulers where the first hash char is not",
+      "separated by space"
+    ],
+    "hashruler_min_length": 10,
+    "_help_canonicalize_hashrulers": [
+      "If true, then insert a space between the first hash char and",
+      "remaining hash chars in a hash ruler, and normalize its",
+      "length to fill the column"
+    ],
+    "canonicalize_hashrulers": true,
+    "_help_enable_markup": [
+      "enable comment markup parsing and reflow"
+    ],
+    "enable_markup": false
+  },
+  "_help_lint": "Options affecting the linter",
+  "lint": {
+    "_help_disabled_codes": [
+      "a list of lint codes to disable"
+    ],
+    "disabled_codes": [],
+    "_help_function_pattern": [
+      "regular expression pattern describing valid function names"
+    ],
+    "function_pattern": "[0-9a-z_]+",
+    "_help_macro_pattern": [
+      "regular expression pattern describing valid macro names"
+    ],
+    "macro_pattern": "[0-9A-Z_]+",
+    "_help_global_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "variables with global scope"
+    ],
+    "global_var_pattern": "[0-9A-Z][0-9A-Z_]+",
+    "_help_internal_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "variables with global scope (but internal semantic)"
+    ],
+    "internal_var_pattern": "_[0-9A-Z][0-9A-Z_]+",
+    "_help_local_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "variables with local scope"
+    ],
+    "local_var_pattern": "[0-9a-z_]+",
+    "_help_private_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "privatedirectory variables"
+    ],
+    "private_var_pattern": "_[0-9a-z_]+",
+    "_help_public_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "publicdirectory variables"
+    ],
+    "public_var_pattern": "[0-9A-Z][0-9A-Z_]+",
+    "_help_keyword_pattern": [
+      "regular expression pattern describing valid names for",
+      "keywords used in functions or macros"
+    ],
+    "keyword_pattern": "[0-9A-Z_]+",
+    "_help_max_conditionals_custom_parser": [
+      "In the heuristic for C0201, how many conditionals to match",
+      "within a loop in before considering the loop a parser."
+    ],
+    "max_conditionals_custom_parser": 2,
+    "_help_min_statement_spacing": [
+      "Require at least this many newlines between statements"
+    ],
+    "min_statement_spacing": 1,
+    "_help_max_statement_spacing": [
+      "Require no more than this many newlines between statements"
+    ],
+    "max_statement_spacing": 1,
+    "max_returns": 6,
+    "max_branches": 12,
+    "max_arguments": 5,
+    "max_localvars": 15,
+    "max_statements": 50
+  },
+  "_help_encode": "Options affecting file encoding",
+  "encode": {
+    "_help_emit_byteorder_mark": [
+      "If true, emit the unicode byte-order mark (BOM) at the start",
+      "of the file"
+    ],
+    "emit_byteorder_mark": false,
+    "_help_input_encoding": [
+      "Specify the encoding of the input file. Defaults to utf-8"
+    ],
+    "input_encoding": "utf-8",
+    "_help_output_encoding": [
+      "Specify the encoding of the output file. Defaults to utf-8.",
+      "Note that cmake only claims to support utf-8 so be careful",
+      "when using anything else"
+    ],
+    "output_encoding": "utf-8"
+  },
+  "_help_misc": "Miscellaneous configurations options.",
+  "misc": {
+    "_help_per_command": [
+      "A dictionary containing any per-command configuration",
+      "overrides. Currently only `command_case` is supported."
+    ],
+    "per_command": {}
+  }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,17 @@
-# Copyright (c) Open Enclave SDK contributors.
-# Licensed under the MIT License.
+# Copyright (c) Open Enclave SDK contributors. Licensed under the MIT License.
 
 # Version 3.1 required for CMAKE_CXX_STANDARD
 cmake_minimum_required(VERSION 3.1)
+
+# Set CMAKE_BUILD_TYPE if not specified
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug")
+endif ()
+
+if (NOT ";Debug;RelWithDebInfo;Release;" MATCHES ";${CMAKE_BUILD_TYPE};")
+  message(
+    FATAL_ERROR "CMAKE_BUILD_TYPE must be Debug, RelWithDebInfo or Release")
+endif ()
 
 project(oeedger8r)
 
@@ -20,3 +29,21 @@ set_property(TARGET oeedger8r PROPERTY POSITION_INDEPENDENT_CODE on)
 enable_testing()
 add_subdirectory(test)
 
+option(CODE_COVERAGE "Enable code coverage testing" OFF)
+if (CODE_COVERAGE)
+  if (NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    message(FATAL_ERROR "Code coverage is supported only with GCC.")
+  endif ()
+
+  message("Building for code coverage.")
+  target_compile_options(oeedger8r PRIVATE -g -O0 -coverage)
+  target_link_libraries(oeedger8r PRIVATE -coverage)
+
+  add_custom_target(
+    code_coverage
+    # Build only edger8r target.
+    # Other targets will be (re)built by code-coverage script.
+    COMMAND cmake --build . -j 4 --target oeedger8r
+    COMMAND ${PROJECT_SOURCE_DIR}/scripts/code-coverage .
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endif ()

--- a/README.md
+++ b/README.md
@@ -115,3 +115,60 @@ Test project oeedger8r-cpp/build
 
 Total Test time (real) =   0.10 sec
 ```
+
+# Code Coverage
+
+Code Coverage is supported only when building with GCC.
+Additionally code coverage requires `lcov`, and python `lcov_cobertura` package.
+```bash
+sudo apt install lcov
+pip3 install lcov_cobertura
+```
+
+To obtain code coverage, configure cmake by passing `-DCODE_COVERAGE=on` to cmake.
+```bash
+cd build
+cmake .. -DCODE_COVERAGE=on
+```
+
+The output would show that oeedger8r will be built for code coverage.
+```bash
+Building for code coverage.
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /home/anakrish/work/oeedger8r-cpp/build
+```
+
+To obtain code coverage, run `make code_coverage`.
+That will build oeedger8r, run tests and generate code-coverage report as html, as well as cobertura xml.
+
+```bash
+Writing data to ./oeedger8r_total_filtered.info
+Summary coverage rate:
+  lines......: 74.0% (1303 of 1762 lines)
+  functions..: 88.3% (218 of 247 functions)
+  branches...: no data found
+Generating html report...
+Reading data file ./oeedger8r_total_filtered.info
+Found 11 entries.
+Found common filename prefix "/home/anakrish/work"
+Writing .css and .png files.
+Generating output.
+Processing file oeedger8r-cpp/lexer.h
+Processing file oeedger8r-cpp/lexer.cpp
+Processing file oeedger8r-cpp/args_h_emitter.h
+Processing file oeedger8r-cpp/utils.h
+Processing file oeedger8r-cpp/ast.h
+Processing file oeedger8r-cpp/h_emitter.h
+Processing file oeedger8r-cpp/c_emitter.h
+Processing file oeedger8r-cpp/f_emitter.h
+Processing file oeedger8r-cpp/parser.cpp
+Processing file oeedger8r-cpp/w_emitter.h
+Processing file oeedger8r-cpp/main.cpp
+Writing directory view page.
+Overall coverage rate:
+  lines......: 74.0% (1303 of 1762 lines)
+  functions..: 88.3% (218 of 247 functions)
+Generating cobertura xml...
+Built target code_coverage
+```

--- a/scripts/code-coverage
+++ b/scripts/code-coverage
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+DIR=$1
+
+# Delete existing coverage data
+echo "Deleting previous coverage information..."
+find "$DIR" -type f -name '*.gcda' -delete
+
+# Create zero coverage data
+echo "Generating coverage baseline..."
+lcov -d "$DIR" -c -i -o "$DIR/oeedger8r_base.info" \
+     --rc lcov_branch_coverage=1 \
+     --rc geninfo_auto_base=1
+
+# Delete generated C and h files so that edger8r will be run again.
+echo "Deleting generated .h and .c files..."
+find "$DIR" -type f -name '*.h' -delete
+find "$DIR" -type f -name '*.c' -delete
+
+# Build the project
+echo "Building project..."
+cmake --build . -j 4
+
+# Run tests
+echo "Running tests..."
+ctest
+
+# Capture coverage data.
+echo "Generating coverage info..."
+lcov -d "$DIR" -c -o "$DIR/oeedger8r_test.info" \
+     --rc lcov_branch_coverage=1 \
+     --rc geninfo_auto_base=1
+
+
+# Combine traces
+echo "Combining coverage info..."
+lcov --add-tracefile "$DIR/oeedger8r_base.info" \
+     --add-tracefile "$DIR/oeedger8r_test.info" \
+     -o "$DIR/oeedger8r_total.info"
+
+# Remove unwanted items
+echo "Filtering coverage info..."
+lcov --remove "$DIR/oeedger8r_total.info" \
+     '/usr/include/*' \
+     '/usr/lib/*' \
+     -o "$DIR/oeedger8r_total_filtered.info"
+
+# Generate HTML report
+echo "Generating html report..."
+mkdir -p "$DIR/html"
+
+genhtml --ignore-errors source \
+	--legend --title "oeedger8r code coverage report" \
+	--output-directory="$DIR/html" \
+	"$DIR/oeedger8r_total_filtered.info"
+
+
+# Generate cobertura xml
+echo "Generating cobertura xml..."
+python3 -m lcov_cobertura \
+	"$DIR/oeedger8r_total_filtered.info" \
+	-o "$DIR/coverage.xml"

--- a/scripts/format-cmake
+++ b/scripts/format-cmake
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+##==============================================================================
+##
+## Echo if verbose flag (ignores quiet flag)
+##
+##==============================================================================
+log_verbose()
+{
+    if [[ ${verbose} -eq 1 ]]; then
+        echo "$1"
+    fi
+}
+
+##==============================================================================
+##
+## Echo if whatif flag is specified but not quiet flag
+##
+##==============================================================================
+log_whatif()
+{
+    if [[ ${whatif} -eq 1 && ${quiet} -ne 1 ]]; then
+        echo "$1"
+    fi
+}
+
+##==============================================================================
+##
+## Process command-line options:
+##
+##==============================================================================
+
+for opt in "$@"
+do
+  case $opt in
+    -h | --help)
+        usage=1
+        ;;
+
+    -v | --verbose)
+        verbose=1
+        ;;
+
+    -q | --quiet)
+        quiet=1
+        ;;
+
+    -w | --whatif)
+        whatif=1
+        ;;
+
+    -s | --staged)
+        # Split into array
+        mapfile -t userFiles <<< "$(git diff --cached --name-only --diff-filter=ACMR)"
+        ;;
+
+    --exclude-dirs=*)
+        userExcludeDirs="${opt#*=}"
+        ;;
+
+    --include-exts=*)
+        userIncludeExts="${opt#*=}"
+        ;;
+
+    --files=*)
+        read -ra userFiles <<< "${opt#*=}"
+        ;;
+    *)
+        echo "$0: unknown option:  $opt"
+        exit 1
+        ;;
+  esac
+done
+
+##==============================================================================
+##
+## Display help
+##
+##==============================================================================
+
+if [[ ${usage} -eq 1 ]]; then
+    cat<<EOF
+
+OVERVIEW:
+
+Formats all CMake files based on the .cmake-format rules
+
+    $ format-cmake [-h] [-q] [-s] [-v] [-w] [--exclude-dirs="..."] [--include-exts="..."] [--files="..."]
+
+OPTIONS:
+    -h, --help              Print this help message.
+    -q, --quiet             Display only cmake-format output and errors.
+    -s, --staged            Only format files which are staged to be committed.
+    -v, --verbose           Display verbose output.
+    -w, --whatif            Run the script without actually modifying the files
+                            and display the diff of expected changes, if any.
+    --exclude-dirs          Subdirectories to exclude. If unspecified, then
+                            ./3rdparty, ./build and ./prereqs are excluded.
+                            All subdirectories are relative to the current path.
+    --include-exts          File extensions to include for formatting. If
+                            unspecified, then *.cmake and CMakeLists.txt are
+                            included.
+    --files                 Only run the script against the specified files from
+                            the current directory.
+
+EXAMPLES:
+
+To determine what lines of each file in the default configuration would be
+modified by format-cmake, you can run from the root folder:
+
+    $ ./scripts/format-cmake -w
+
+To update only CMake files in tests/ except for tests/echo/host, you
+can run from the tests folder:
+
+    tests$ ../scripts/format-cmake --exclude-dirs="echo/host"
+
+To run only against a specified set of comma separated files in the current directory:
+
+    $ ./scripts/format-cmake -w --files="file1 file2"
+
+EOF
+    exit 0
+fi
+
+##==============================================================================
+##
+## Check for acceptable version of cmake-format
+##
+##==============================================================================
+check_version()
+{
+    # shellcheck disable=SC2206
+    v1=(${1//./ })
+    # shellcheck disable=SC2206
+    v2=(${2//./ })
+    if [[ ${#v1[@]} -ne ${#v2[@]} ]]; then
+        echo "Cannot parse cmake-format version number: $2"
+        exit 1
+    fi
+    for ((i=0; i<${#v1[@]}; i++));
+    do
+        # Because cmake-format is not invariant across versions, this
+        # is an explicit equivalence check.
+        if [[ ${v1[$i]} -ne ${v2[$i]} ]]; then
+            echo "Warning: format-cmake prefers cmake-format version $1, installed version is $2"
+        fi
+    done
+}
+
+##==============================================================================
+##
+## Check for installed cmake-format tool
+##
+##==============================================================================
+check_cmake-format()
+{
+    cf=$(command -v cmake-format 2> /dev/null)
+    if [[ ! -x ${cf} ]]; then
+        echo "cmake-format is not installed"
+        exit 1
+    fi
+    cf="cmake-format"
+
+    local required_cfver='0.6.9'
+    # shellcheck disable=SC2155
+    local cfver=$(${cf} --version 2>&1)
+    check_version "${required_cfver}" "${cfver}"
+}
+
+check_cmake-format
+
+##==============================================================================
+##
+## Determine parameters for finding files to format
+##
+##==============================================================================
+
+findargs='find .'
+
+get_find_args()
+{
+    local defaultExcludeDirs='./.git ./3rdparty ./prereqs ./build *.cquery_cached_index'
+    local defaultIncludeExts='cmake'
+
+    if [[ -z ${userExcludeDirs} ]]; then
+        read -r -a excludeDirs <<< "${defaultExcludeDirs}"
+    else
+        log_verbose "Using user directory exclusions: ${userExcludeDirs}"
+        read -r -a excludeDirs <<< "${userExcludeDirs}"
+    fi
+
+    for exc in "${excludeDirs[@]}"
+    do
+        findargs="${findargs} ! \( -path '${exc}' -prune \)"
+    done
+
+    if [[ -z ${userIncludeExts} ]]; then
+        # not local as this is used in get_file_list() too
+        read -r -a includeExts <<< "${defaultIncludeExts}"
+    else
+        log_verbose "Using user extension inclusions: ${userIncludeExts}"
+        read -r -a includeExts <<< "${userIncludeExts}"
+    fi
+
+    findargs="${findargs} \( -iname 'CMakeLists.txt'"
+    for ((i=0; i<${#includeExts[@]}; i++));
+    do
+        findargs="${findargs} -o -iname '*.${includeExts[$i]}'"
+    done
+    findargs="${findargs} \)"
+}
+
+get_find_args
+
+log_verbose "Query for files for format:"
+log_verbose "${findargs}"
+log_verbose ""
+
+##==============================================================================
+##
+## Call cmake-format for each file to be formatted
+##
+##==============================================================================
+
+filecount=0
+changecount=0
+
+cfargs="${cf}"
+if [[ ${whatif} -ne 1 ]]; then
+    cfargs="${cfargs} -i"
+fi
+
+get_file_list()
+{
+    if [[ -z "${userFiles[*]}" ]]; then
+        mapfile -t file_list < <(eval "$findargs")
+        if [[ ${#file_list[@]} -eq 0 ]]; then
+            echo "No files were found to format!"
+            exit 1
+        fi
+    else
+        log_verbose "Using user files: ${userFiles[*]}"
+        file_list=()
+        for file in "${userFiles[@]}"; do
+            if [[ ${file##*/} == "CMakeLists.txt" ]]; then
+                file_list+=( "$file" )
+                log_verbose "Checking user file: ${file}"
+            else
+                for ext in "${includeExts[@]}"; do
+                    if [[ ${file##*\.} == "$ext" ]]; then
+                        file_list+=( "$file" )
+                        log_verbose "Checking user file: ${file}"
+                        break
+                    fi
+                done
+            fi
+        done
+    fi
+}
+
+get_file_list
+
+for file in "${file_list[@]}"
+do
+    ((filecount+=1))
+    cf="${cfargs} $file"
+
+    log_whatif "Formatting $file ..."
+
+    if [[ ${whatif} -eq 1 ]]; then
+        ${cf} | diff -u "$file" -
+    else
+        if [[ ${verbose} -eq 1 ]]; then
+            ${cf}
+        else
+            ${cf} > /dev/null
+        fi
+    fi
+
+    #shellcheck disable=SC2181
+    if [[ $? -ne 0 ]]; then
+        if [[ ${whatif} -eq 1 ]]; then
+            ((changecount+=1))
+        else
+            echo "cmake-format failed on file: $file."
+        fi
+    fi
+done
+
+log_whatif "${filecount} files processed, ${changecount} changed."
+
+# If files are being edited, this count is zero so we exit with success.
+exit "$changecount"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -39,3 +39,7 @@ scripts=$(git rev-parse --show-toplevel)/scripts
 if ! "$scripts/format-code" --quiet --whatif --files="${files[*]}"; then
     exit_ "Commit failed: please run './scripts/format-code --staged' to fix the formatting"
 fi
+
+if ! "$scripts/format-cmake" --quiet --whatif --files="${files[*]}"; then
+    exit_ "Commit failed: please run './scripts/format-cmake --staged' to fix the formatting"
+fi


### PR DESCRIPTION
To enable code coverage, pass -DCODE_COVERAGE=on to cmake.
Then run `make code_coverage` to build oeedger8r and generate
code-coverage report.

Html report can be accessed at build/html/index.html
Cobertura report is available at build/coverage.xml

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>