### PR TITLE
Cleanup generated header files

### DIFF
--- a/c_emitter.h
+++ b/c_emitter.h
@@ -56,13 +56,21 @@ class CEmitter
               << ""
               << "OE_EXTERNC_BEGIN"
               << ""
-              << "/**** ECALL functions. ****/"
+              << "/**** Trusted function IDs ****/";
+        trusted_function_ids();
+        out() << "/**** ECALL marshalling structs. ****/";
+        ecall_marshalling_structs();
+        out() << "/**** ECALL functions. ****/"
               << "";
         for (Function* f : edl_->trusted_funcs_)
             emit_forwarder(f);
         out() << "/**** ECALL function table. ****/"
               << "";
         ecalls_table();
+        out() << "/**** Untrusted function IDs. ****/";
+        untrusted_function_ids();
+        out() << "/**** OCALL marshalling structs. ****/";
+        ocall_marshalling_structs();
         out() << "/**** OCALL function wrappers. ****/"
               << "";
         for (Function* f : edl_->untrusted_funcs_)
@@ -84,10 +92,18 @@ class CEmitter
               << ""
               << "OE_EXTERNC_BEGIN"
               << ""
-              << "/**** ECALL function wrappers. ****/"
+              << "/**** Trusted function IDs ****/";
+        trusted_function_ids();
+        out() << "/**** ECALL marshalling structs. ****/";
+        ecall_marshalling_structs();
+        out() << "/**** ECALL function wrappers. ****/"
               << "";
         for (Function* f : edl_->trusted_funcs_)
             emit_wrapper(f);
+        out() << "/**** Untrusted function IDs. ****/";
+        untrusted_function_ids();
+        out() << "/**** OCALL marshalling structs. ****/";
+        ocall_marshalling_structs();
         out() << "/**** OCALL functions. ****/"
               << "";
         for (Function* f : edl_->untrusted_funcs_)
@@ -112,6 +128,65 @@ class CEmitter
               << ""
               << "OE_EXTERNC_END";
         file_.close();
+    }
+
+    void trusted_function_ids()
+    {
+        out() << "enum"
+              << "{";
+        int idx = 0;
+        std::string pfx = "    " + edl_->name_ + "_fcn_id_";
+        for (Function* f : edl_->trusted_funcs_)
+            out() << pfx + f->name_ + " = " + to_str(idx++) + ",";
+        out() << pfx + "trusted_call_id_max = OE_ENUM_MAX"
+              << "};"
+              << "";
+    }
+
+    void untrusted_function_ids()
+    {
+        out() << "enum"
+              << "{";
+        int idx = 0;
+        std::string pfx = "    " + edl_->name_ + "_fcn_id_";
+        for (Function* f : edl_->untrusted_funcs_)
+            out() << pfx + f->name_ + " = " + to_str(idx++) + ",";
+        out() << pfx + "untrusted_call_max = OE_ENUM_MAX"
+              << "};"
+              << "";
+    }
+    void ecall_marshalling_structs()
+    {
+        for (Function* f : edl_->trusted_funcs_)
+            marshalling_struct(f, false);
+    }
+
+    void ocall_marshalling_structs()
+    {
+        for (Function* f : edl_->untrusted_funcs_)
+            marshalling_struct(f, true);
+    }
+
+    void marshalling_struct(Function* f, bool ocall = false)
+    {
+        (void)ocall;
+        out() << "typedef struct _" + f->name_ + "_args_t"
+              << "{"
+              << "    oe_result_t _result;";
+        indent_ = "    ";
+        if (f->rtype_->tag_ != Void)
+            out() << atype_str(f->rtype_) + " _retval;";
+        for (Decl* p : f->params_)
+        {
+            out() << mdecl_str(p->name_, p->type_, p->dims_, p->attrs_) + ";";
+            if (p->attrs_ && (p->attrs_->string_ || p->attrs_->wstring_))
+                out() << "size_t " + p->name_ + "_len;";
+        }
+        if (f->errno_)
+            out() << "int _ocall_errno;";
+        indent_ = "";
+        out() << "} " + f->name_ + "_args_t;"
+              << "";
     }
 
     void ecalls_table()

--- a/h_emitter.h
+++ b/h_emitter.h
@@ -73,81 +73,13 @@ class HEmitter
         if (!gen_t_h_)
             out() << create_prototype(edl_->name_) + ";"
                   << "";
-        out() << "/**** Trusted function IDs ****/";
-        trusted_function_ids();
-        out() << "/**** ECALL marshalling structs. ****/";
-        ecall_marshalling_structs();
         out() << "/**** ECALL prototypes. ****/";
         trusted_prototypes();
-        out() << "/**** Untrusted function IDs. ****/";
-        untrusted_function_ids();
-        out() << "/**** OCALL marshalling structs. ****/";
-        ocall_marshalling_structs();
         out() << "/**** OCALL prototypes. ****/";
         untrusted_prototypes();
         out() << "OE_EXTERNC_END"
               << "";
         footer(out(), guard);
-    }
-
-    void trusted_function_ids()
-    {
-        out() << "enum"
-              << "{";
-        int idx = 0;
-        std::string pfx = "    " + edl_->name_ + "_fcn_id_";
-        for (Function* f : edl_->trusted_funcs_)
-            out() << pfx + f->name_ + " = " + to_str(idx++) + ",";
-        out() << pfx + "trusted_call_id_max = OE_ENUM_MAX"
-              << "};"
-              << "";
-    }
-
-    void untrusted_function_ids()
-    {
-        out() << "enum"
-              << "{";
-        int idx = 0;
-        std::string pfx = "    " + edl_->name_ + "_fcn_id_";
-        for (Function* f : edl_->untrusted_funcs_)
-            out() << pfx + f->name_ + " = " + to_str(idx++) + ",";
-        out() << pfx + "untrusted_call_max = OE_ENUM_MAX"
-              << "};"
-              << "";
-    }
-
-    void ecall_marshalling_structs()
-    {
-        for (Function* f : edl_->trusted_funcs_)
-            marshalling_struct(f, false);
-    }
-
-    void ocall_marshalling_structs()
-    {
-        for (Function* f : edl_->untrusted_funcs_)
-            marshalling_struct(f, true);
-    }
-
-    void marshalling_struct(Function* f, bool ocall = false)
-    {
-        (void)ocall;
-        out() << "typedef struct _" + f->name_ + "_args_t"
-              << "{"
-              << "    oe_result_t _result;";
-        indent_ = "    ";
-        if (f->rtype_->tag_ != Void)
-            out() << atype_str(f->rtype_) + " _retval;";
-        for (Decl* p : f->params_)
-        {
-            out() << mdecl_str(p->name_, p->type_, p->dims_, p->attrs_) + ";";
-            if (p->attrs_ && (p->attrs_->string_ || p->attrs_->wstring_))
-                out() << "size_t " + p->name_ + "_len;";
-        }
-        if (f->errno_)
-            out() << "int _ocall_errno;";
-        indent_ = "";
-        out() << "} " + f->name_ + "_args_t;"
-              << "";
     }
 
     void trusted_prototypes()

--- a/test/comprehensive/enc/CMakeLists.txt
+++ b/test/comprehensive/enc/CMakeLists.txt
@@ -29,19 +29,17 @@ add_custom_command(
 
 add_library(
   oeedger8r_comprehensive_enc SHARED
-  all_t.c
+  all_t.h
+  all_t_wrapper.cpp
   bar_t.h
   config.cpp
   foo.cpp
   testaliasing.cpp
   testarray.cpp
-  testbasic.cpp
   testdeepcopy.cpp
   testenum.cpp
-  testerrno.cpp
   testforeign.cpp
   testpointer.cpp
-  teststring.cpp
   teststruct.cpp
   testswitchless.cpp)
 

--- a/test/comprehensive/enc/all_t_wrapper.cpp
+++ b/test/comprehensive/enc/all_t_wrapper.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "all_t.c"
+#include "testbasic.cpp"
+#include "testerrno.cpp"
+#include "teststring.cpp"

--- a/test/comprehensive/host/CMakeLists.txt
+++ b/test/comprehensive/host/CMakeLists.txt
@@ -29,19 +29,17 @@ add_custom_command(
 
 add_executable(
   oeedger8r_comprehensive_host
-  all_u.c
+  all_u.h
+  all_u_wrapper.cpp
   bar_u.h
   main.cpp
   bar.cpp
   foo.cpp
   testarray.cpp
-  testbasic.cpp
   testdeepcopy.cpp
   testenum.cpp
-  testerrno.cpp
   testforeign.cpp
   testpointer.cpp
-  teststring.cpp
   teststruct.cpp
   testswitchless.cpp)
 

--- a/test/comprehensive/host/all_u_wrapper.cpp
+++ b/test/comprehensive/host/all_u_wrapper.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include "all_u.c"
+#include "testbasic.cpp"
+#include "testerrno.cpp"
+#include "teststring.cpp"

--- a/test/virtual/include/openenclave/corelibc/string.h
+++ b/test/virtual/include/openenclave/corelibc/string.h
@@ -12,6 +12,12 @@
 #include <openenclave/bits/types.h>
 #include <openenclave/corelibc/bits/defs.h>
 
+#ifdef __cplusplus
+#define OE_NOTHROW throw()
+#else
+#define OE_NOTHROW
+#endif
+
 OE_EXTERNC_BEGIN
 
 /*
@@ -23,10 +29,11 @@ OE_EXTERNC_BEGIN
 */
 
 /* The mem methods are always defined by their stdc names in oecore */
-int memcmp(const void* vl, const void* vr, size_t n);
-void* memcpy(void* OE_RESTRICT dest, const void* OE_RESTRICT src, size_t n);
-void* memmove(void* dest, const void* src, size_t n);
-void* memset(void* dest, int c, size_t n);
+int memcmp(const void* vl, const void* vr, size_t n) OE_NOTHROW;
+void* memcpy(void* OE_RESTRICT dest, const void* OE_RESTRICT src, size_t n)
+    OE_NOTHROW;
+void* memmove(void* dest, const void* src, size_t n) OE_NOTHROW;
+void* memset(void* dest, int c, size_t n) OE_NOTHROW;
 
 size_t oe_strlen(const char* s);
 


### PR DESCRIPTION
This makes generated headers consistent with Intel SDK sgx_edger8r.

The generated header files will contain only the function prototypes.
Marshalling structs, function id enums, and function tables are generated
only in the appropriate c file.

Also add NO_THROW declaration to corelibc/string.h to make it C++ conformant.

Some tests lock down the fields of the generated structs in all_t.c and all_u.c.
Therefore all_u_wrapper.cpp and all_t_wrapper.cpp are introduced to include
the generated source files together with the test files that need access to the
structs.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>