### PR TITLE
--use-prefix feature.

### DIFF
--- a/c_emitter.h
+++ b/c_emitter.h
@@ -81,7 +81,9 @@ class CEmitter
         file_.close();
     }
 
-    void emit_u_c(const std::string& dir_with_sep = "")
+    void emit_u_c(
+        const std::string& dir_with_sep = "",
+        const std::string& prefix = "")
     {
         gen_t_c_ = false;
         file_.open(dir_with_sep + edl_->name_ + "_u.c");
@@ -99,7 +101,7 @@ class CEmitter
         out() << "/**** ECALL function wrappers. ****/"
               << "";
         for (Function* f : edl_->trusted_funcs_)
-            emit_wrapper(f);
+            emit_wrapper(f, prefix);
         out() << "/**** Untrusted function IDs. ****/";
         untrusted_function_ids();
         out() << "/**** OCALL marshalling structs. ****/";
@@ -219,9 +221,9 @@ class CEmitter
         FEmitter(edl_, file_).emit(f, gen_t_c_);
     }
 
-    void emit_wrapper(Function* f)
+    void emit_wrapper(Function* f, const std::string& prefix = "")
     {
-        WEmitter(edl_, file_).emit(f, !gen_t_c_);
+        WEmitter(edl_, file_).emit(f, !gen_t_c_, prefix);
     }
 };
 

--- a/h_emitter.h
+++ b/h_emitter.h
@@ -49,15 +49,17 @@ class HEmitter
         file_.close();
     }
 
-    void emit_u_h(const std::string& dir_with_sep = "")
+    void emit_u_h(
+        const std::string& dir_with_sep = "",
+        const std::string& prefix = "")
     {
         gen_t_h_ = false;
         file_.open(dir_with_sep + edl_->name_ + "_u.h");
-        emit_h();
+        emit_h(prefix);
         file_.close();
     }
 
-    void emit_h()
+    void emit_h(const std::string& prefix = "")
     {
         std::string guard =
             "EDGER8R_" + upper(edl_->name_) + (gen_t_h_ ? "_T" : "_U") + "_H";
@@ -74,7 +76,7 @@ class HEmitter
             out() << create_prototype(edl_->name_) + ";"
                   << "";
         out() << "/**** ECALL prototypes. ****/";
-        trusted_prototypes();
+        trusted_prototypes(prefix);
         out() << "/**** OCALL prototypes. ****/";
         untrusted_prototypes();
         out() << "OE_EXTERNC_END"
@@ -82,10 +84,11 @@ class HEmitter
         footer(out(), guard);
     }
 
-    void trusted_prototypes()
+    void trusted_prototypes(const std::string& prefix = "")
     {
+        // Prefix is generated, if specified, only in _u.h.
         for (Function* f : edl_->trusted_funcs_)
-            out() << prototype(f, true, gen_t_h_) + ";"
+            out() << prototype(f, true, gen_t_h_, prefix) + ";"
                   << "";
         if (edl_->trusted_funcs_.empty())
             out() << "";

--- a/main.cpp
+++ b/main.cpp
@@ -48,6 +48,7 @@ const char* usage =
 int main(int argc, char** argv)
 {
     std::vector<std::string> searchpaths;
+    bool use_prefix = false;
     bool header_only = false;
     bool gen_untrusted = false;
     bool gen_trusted = false;
@@ -81,7 +82,7 @@ int main(int argc, char** argv)
         if (a == "--search-path")
             searchpaths.push_back(get_dir(i++));
         else if (a == "--use-prefix")
-            continue;
+            use_prefix = true;
         else if (a == "--header-only")
             header_only = true;
         else if (a == "--untrusted")
@@ -142,10 +143,11 @@ int main(int argc, char** argv)
         }
         if (gen_untrusted)
         {
+            std::string prefix = use_prefix ? (edl->name_ + "_") : "";
             ArgsHEmitter(edl).emit(untrusted_dir);
-            HEmitter(edl).emit_u_h(untrusted_dir);
+            HEmitter(edl).emit_u_h(untrusted_dir, prefix);
             if (!header_only)
-                CEmitter(edl).emit_u_c(untrusted_dir);
+                CEmitter(edl).emit_u_c(untrusted_dir, prefix);
         }
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(behavior)
 add_subdirectory(cmdline)
 add_subdirectory(comprehensive)
 add_subdirectory(import)
+add_subdirectory(prefix)
 
 # Virtual Mode execution for tests.
 add_subdirectory(virtual)

--- a/test/prefix/CMakeLists.txt
+++ b/test/prefix/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(enc1)
+add_subdirectory(enc2)
+add_subdirectory(host)
+
+add_test(oeedger8r_prefix host/oeedger8r_prefix_host enc1/oeedger8r_enc1
+         enc2/oeedger8r_enc2)

--- a/test/prefix/common.edl
+++ b/test/prefix/common.edl
@@ -1,0 +1,38 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+
+  // Define a struct to ensure that multiple definition error does not occur.
+  struct MyStruct {
+    int x;
+    int64_t y;
+  };
+
+  // Define an union to ensure that multiple definition error does not occur.
+  union MyUnion {
+    int x;
+    int64_t y;
+  };
+
+  // Define an enum to ensure that multiple definition error does not occur.
+  enum MyEnum {
+    RED,
+    GREEN = 10,
+    BLUE
+  };
+
+  trusted {
+     // Common ecalls.
+     public void enc_ecall1(MyStruct s);
+     public void enc_ecall2(MyUnion u);
+     public void enc_ecall3(MyEnum e);
+  };
+
+  untrusted {
+     // Common ocalls
+     void host_ocall1(MyStruct s);
+     void host_ocall2(MyUnion u);
+     void host_ocall3(MyEnum e);
+  };
+};

--- a/test/prefix/enc1.edl
+++ b/test/prefix/enc1.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+
+  // Import all functions.
+  from "common.edl" import *;
+
+};

--- a/test/prefix/enc1/CMakeLists.txt
+++ b/test/prefix/enc1/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_custom_command(
+  OUTPUT enc1_args.h enc1_t.h enc1_t.c
+  COMMAND oeedger8r --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..
+          enc1.edl
+  DEPENDS ../common.edl ../enc1.edl)
+
+add_library(oeedger8r_enc1 SHARED enc1_t.c enc.c)
+
+target_include_directories(oeedger8r_enc1 PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(oeedger8r_enc1 oeedger8r_test_enclave)
+
+set_target_properties(oeedger8r_enc1 PROPERTIES PREFIX "")

--- a/test/prefix/enc1/enc.c
+++ b/test/prefix/enc1/enc.c
@@ -1,0 +1,24 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/tests.h>
+#include "enc1_t.h"
+
+void enc_ecall1(MyStruct s)
+{
+    OE_TEST(s.x == 5);
+    OE_TEST(s.y == 6);
+    OE_TEST(host_ocall1(s) == OE_OK);
+}
+
+void enc_ecall2(MyUnion u)
+{
+    OE_TEST(u.y == 7);
+    OE_TEST(host_ocall2(u) == OE_OK);
+}
+
+void enc_ecall3(MyEnum e)
+{
+    OE_TEST(e == GREEN);
+    OE_TEST(host_ocall3(e) == OE_OK);
+}

--- a/test/prefix/enc2.edl
+++ b/test/prefix/enc2.edl
@@ -1,0 +1,14 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+
+  // Selectively import calls and ocalls.
+  // All types are imported.
+  from "common.edl" import
+    enc_ecall2,
+    enc_ecall1,
+    host_ocall1,
+    host_ocall2;
+
+};

--- a/test/prefix/enc2/CMakeLists.txt
+++ b/test/prefix/enc2/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_custom_command(
+  OUTPUT enc2_args.h enc2_t.h enc2_t.c
+  COMMAND oeedger8r --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..
+          enc2.edl
+  DEPENDS ../common.edl ../enc2.edl)
+
+add_library(oeedger8r_enc2 SHARED enc2_t.c enc.c)
+
+target_include_directories(oeedger8r_enc2 PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(oeedger8r_enc2 oeedger8r_test_enclave)
+
+set_target_properties(oeedger8r_enc2 PROPERTIES PREFIX "")

--- a/test/prefix/enc2/enc.c
+++ b/test/prefix/enc2/enc.c
@@ -1,0 +1,18 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/tests.h>
+#include "enc2_t.h"
+
+void enc_ecall1(MyStruct s)
+{
+    OE_TEST(s.x == 8);
+    OE_TEST(s.y == 9);
+    OE_TEST(host_ocall1(s) == OE_OK);
+}
+
+void enc_ecall2(MyUnion u)
+{
+    OE_TEST(u.y == 10);
+    OE_TEST(host_ocall2(u) == OE_OK);
+}

--- a/test/prefix/host/CMakeLists.txt
+++ b/test/prefix/host/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Open Enclave SDK contributors. Licensed under the MIT License.
+
+add_custom_command(
+  OUTPUT enc1_args.h enc1_u.h enc1_u.c
+  COMMAND oeedger8r --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..
+          enc1.edl
+  DEPENDS ../common.edl ../enc1.edl)
+
+add_custom_command(
+  OUTPUT enc2_args.h enc2_u.h enc2_u.c
+  COMMAND oeedger8r --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..
+          enc2.edl --use-prefix
+  DEPENDS ../common.edl ../enc2.edl)
+
+add_executable(oeedger8r_prefix_host enc1_u.c enc2_u.c host.cpp)
+
+target_include_directories(oeedger8r_prefix_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(oeedger8r_prefix_host oeedger8r_test_host)

--- a/test/prefix/host/host.cpp
+++ b/test/prefix/host/host.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <stdio.h>
+
+#include <openenclave/internal/tests.h>
+
+// Ensure that there are no multiple definition errors for user defined types.
+#include "enc1_u.h"
+#include "enc2_u.h"
+
+MyStruct g_s = {5, 6};
+MyUnion g_u = {7};
+MyEnum g_e = GREEN;
+
+void host_ocall1(MyStruct s)
+{
+    OE_TEST(s.x == g_s.x);
+    OE_TEST(s.y == g_s.y);
+}
+
+void host_ocall2(MyUnion u)
+{
+    OE_TEST(u.y == g_u.y);
+}
+
+void host_ocall3(MyEnum e)
+{
+    OE_TEST(e == g_e);
+}
+
+int main(int argc, char** argv)
+{
+    oe_enclave_t* enc1 = NULL;
+    oe_enclave_t* enc2 = NULL;
+
+    const uint32_t flags = 0;
+
+    if (argc != 3)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE1_PATH ENCLAVE2_PATH\n", argv[0]);
+        return 1;
+    }
+
+    OE_TEST(
+        oe_create_enc1_enclave(
+            argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enc1) == OE_OK);
+
+    OE_TEST(
+        oe_create_enc2_enclave(
+            argv[2], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enc2) == OE_OK);
+
+    // Call functions in enclave 1.
+    OE_TEST(enc_ecall1(enc1, g_s) == OE_OK);
+    OE_TEST(enc_ecall2(enc1, g_u) == OE_OK);
+    OE_TEST(enc_ecall3(enc1, g_e) == OE_OK);
+
+    // Change values for enclave 2.
+    g_s = {8, 9};
+    g_u.y = 10;
+    OE_TEST(enc2_enc_ecall1(enc2, g_s) == OE_OK);
+    OE_TEST(enc2_enc_ecall2(enc2, g_u) == OE_OK);
+
+    OE_TEST(oe_terminate_enclave(enc1) == OE_OK);
+    OE_TEST(oe_terminate_enclave(enc2) == OE_OK);
+
+    printf("=== passed all tests (prefix)\n");
+}

--- a/utils.h
+++ b/utils.h
@@ -154,7 +154,8 @@ inline std::string mdecl_str(
 inline std::string prototype(
     const Function* f,
     bool ecall = true,
-    bool gen_t = true)
+    bool gen_t = true,
+    const std::string& prefix = "")
 {
     std::string retstr =
         (ecall != gen_t) ? "oe_result_t" : atype_str(f->rtype_);
@@ -181,7 +182,7 @@ inline std::string prototype(
             argsstr += ",\n    " + args[i];
         argsstr += ")";
     }
-    return retstr + " " + f->name_ + argsstr;
+    return retstr + " " + prefix + f->name_ + argsstr;
 }
 
 inline std::string create_prototype(const std::string& ename)

--- a/w_emitter.h
+++ b/w_emitter.h
@@ -73,7 +73,7 @@ class WEmitter
         }
     }
 
-    void emit(Function* f, bool ecall)
+    void emit(Function* f, bool ecall, const std::string& prefix = "")
     {
         ecall_ = ecall;
         std::string alloc_fcn;
@@ -83,7 +83,7 @@ class WEmitter
         std::string other = ecall ? "enclave" : "host";
 
         std::string args_t = f->name_ + "_args_t";
-        out() << prototype(f, ecall, gen_t()) << "{"
+        out() << prototype(f, ecall, gen_t(), prefix) << "{"
               << "    oe_result_t _result = OE_FAILURE;"
               << "";
         enclave_status_check();


### PR DESCRIPTION
When --use-prefix is supplied, then the edl name is prefixed to
all the untrusted proxies (ecall wrappers on the host side).
Ocalls are not affected.

This feature reduces the gap between OE SDK and Intel SDK.

Note:
The implementation  provides the ability to add prefixes to host-side ecall wrappers.
This can be leveraged for a portable weak-symbol implementation.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>