### PR TITLE
ECALL refactoring: Support multiple definitions of ECALLs from different enclaves

### DIFF
--- a/c_emitter.h
+++ b/c_emitter.h
@@ -94,8 +94,10 @@ class CEmitter
               << ""
               << "OE_EXTERNC_BEGIN"
               << ""
-              << "/**** Trusted function IDs ****/";
+              << "/**** Trusted function IDs. ****/";
         trusted_function_ids();
+        out() << "/**** Trusted function names. ****/";
+        trusted_function_names();
         out() << "/**** ECALL marshalling structs. ****/";
         ecall_marshalling_structs();
         out() << "/**** ECALL function wrappers. ****/"
@@ -125,6 +127,8 @@ class CEmitter
               << "               setting_count,"
               << "               __" + edl_->name_ + "_ocall_function_table,"
               << "               " + to_str(edl_->untrusted_funcs_.size()) + ","
+              << "               __" + edl_->name_ + "_ecall_info_table,"
+              << "                " + to_str(edl_->trusted_funcs_.size()) + ","
               << "               enclave);"
               << "}"
               << ""
@@ -145,6 +149,17 @@ class CEmitter
               << "";
     }
 
+    void trusted_function_names()
+    {
+        out() << "static const oe_ecall_info_t __" + edl_->name_ +
+                     "_ecall_info_table[] = "
+              << "{";
+        for (Function* f : edl_->trusted_funcs_)
+            out() << "    { \"" + f->name_ + "\" },";
+        out() << "};"
+              << "";
+    }
+
     void untrusted_function_ids()
     {
         out() << "enum"
@@ -157,6 +172,7 @@ class CEmitter
               << "};"
               << "";
     }
+
     void ecall_marshalling_structs()
     {
         for (Function* f : edl_->trusted_funcs_)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(basic)
 add_subdirectory(behavior)
+add_subdirectory(call_conflict)
 add_subdirectory(cmdline)
 add_subdirectory(comprehensive)
 add_subdirectory(import)

--- a/test/call_conflict/CMakeLists.txt
+++ b/test/call_conflict/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(enc1)
+add_subdirectory(enc2)
+add_subdirectory(host)
+
+add_test(oeedger8r_call_conflict host/oeedger8r_call_conflict_host
+         enc1/oeedger8r_call_conflict_enc1 enc2/oeedger8r_call_conflict_enc2)

--- a/test/call_conflict/common.edl
+++ b/test/call_conflict/common.edl
@@ -1,0 +1,38 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+
+  // Define a struct to ensure that multiple definition error does not occur.
+  struct MyStruct {
+    int x;
+    int64_t y;
+  };
+
+  // Define an union to ensure that multiple definition error does not occur.
+  union MyUnion {
+    int x;
+    int64_t y;
+  };
+
+  // Define an enum to ensure that multiple definition error does not occur.
+  enum MyEnum {
+    RED,
+    GREEN = 10,
+    BLUE
+  };
+
+  trusted {
+     // Common ecalls.
+     public void enc_ecall1(MyStruct s);
+     public void enc_ecall2(MyUnion u);
+     public void enc_ecall3(MyEnum e);
+  };
+
+  untrusted {
+     // Common ocalls
+     void host_ocall1(MyStruct s);
+     void host_ocall2(MyUnion u);
+     void host_ocall3(MyEnum e);
+  };
+};

--- a/test/call_conflict/enc1.edl
+++ b/test/call_conflict/enc1.edl
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+
+  // Import all functions.
+  from "common.edl" import *;
+
+  trusted {
+    public int enc_local_ecall1(int val);
+  };
+};

--- a/test/call_conflict/enc1/CMakeLists.txt
+++ b/test/call_conflict/enc1/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_custom_command(
+  OUTPUT enc1_args.h enc1_t.h enc1_t.c
+  COMMAND oeedger8r --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..
+          enc1.edl
+  DEPENDS ../common.edl ../enc1.edl)
+
+add_library(oeedger8r_call_conflict_enc1 SHARED enc1_t.c enc.c)
+
+target_include_directories(oeedger8r_call_conflict_enc1
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(oeedger8r_call_conflict_enc1 oeedger8r_test_enclave)
+
+set_target_properties(oeedger8r_call_conflict_enc1 PROPERTIES PREFIX "")

--- a/test/call_conflict/enc1/enc.c
+++ b/test/call_conflict/enc1/enc.c
@@ -1,0 +1,30 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/tests.h>
+#include "enc1_t.h"
+
+void enc_ecall1(MyStruct s)
+{
+    OE_TEST(s.x == 5);
+    OE_TEST(s.y == 6);
+    OE_TEST(host_ocall1(s) == OE_OK);
+}
+
+void enc_ecall2(MyUnion u)
+{
+    OE_TEST(u.y == 7);
+    OE_TEST(host_ocall2(u) == OE_OK);
+}
+
+void enc_ecall3(MyEnum e)
+{
+    OE_TEST(e == GREEN);
+    OE_TEST(host_ocall3(e) == OE_OK);
+}
+
+int enc_local_ecall1(int val)
+{
+    OE_TEST(val == 11);
+    return 12;
+}

--- a/test/call_conflict/enc2.edl
+++ b/test/call_conflict/enc2.edl
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+
+  // Selectively import calls and ocalls.
+  // All types are imported.
+  from "common.edl" import
+    enc_ecall2,
+    enc_ecall1,
+    host_ocall1,
+    host_ocall2;
+
+  trusted {
+    public int enc_local_ecall2(int val);
+  };
+};

--- a/test/call_conflict/enc2/CMakeLists.txt
+++ b/test/call_conflict/enc2/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_custom_command(
+  OUTPUT enc2_args.h enc2_t.h enc2_t.c
+  COMMAND oeedger8r --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..
+          enc2.edl
+  DEPENDS ../common.edl ../enc2.edl)
+
+add_library(oeedger8r_call_conflict_enc2 SHARED enc2_t.c enc.c)
+
+target_include_directories(oeedger8r_call_conflict_enc2
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(oeedger8r_call_conflict_enc2 oeedger8r_test_enclave)
+
+set_target_properties(oeedger8r_call_conflict_enc2 PROPERTIES PREFIX "")

--- a/test/call_conflict/enc2/enc.c
+++ b/test/call_conflict/enc2/enc.c
@@ -1,0 +1,24 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/tests.h>
+#include "enc2_t.h"
+
+void enc_ecall1(MyStruct s)
+{
+    OE_TEST(s.x == 8);
+    OE_TEST(s.y == 9);
+    OE_TEST(host_ocall1(s) == OE_OK);
+}
+
+void enc_ecall2(MyUnion u)
+{
+    OE_TEST(u.y == 10);
+    OE_TEST(host_ocall2(u) == OE_OK);
+}
+
+int enc_local_ecall2(int val)
+{
+    OE_TEST(val == 13);
+    return 14;
+}

--- a/test/call_conflict/host/CMakeLists.txt
+++ b/test/call_conflict/host/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Open Enclave SDK contributors. Licensed under the MIT License.
+
+add_custom_command(
+  OUTPUT enc1_args.h enc1_u.h enc1_u.c
+  COMMAND oeedger8r --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..
+          enc1.edl
+  DEPENDS ../common.edl ../enc1.edl)
+
+add_custom_command(
+  OUTPUT enc2_args.h enc2_u.h enc2_u.c
+  COMMAND oeedger8r --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/..
+          enc2.edl
+  DEPENDS ../common.edl ../enc2.edl)
+
+add_executable(oeedger8r_call_conflict_host enc1_u.c enc2_u.c host.cpp)
+
+target_include_directories(oeedger8r_call_conflict_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(oeedger8r_call_conflict_host oeedger8r_test_host)

--- a/test/call_conflict/host/host.cpp
+++ b/test/call_conflict/host/host.cpp
@@ -1,0 +1,243 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <stdio.h>
+
+#include <openenclave/internal/tests.h>
+
+// Ensure that there are no multiple definition errors for user defined types.
+#include "enc1_u.h"
+#include "enc2_u.h"
+
+MyStruct g_s = {5, 6};
+MyUnion g_u = {7};
+MyEnum g_e = GREEN;
+
+void host_ocall1(MyStruct s)
+{
+    OE_TEST(s.x == g_s.x);
+    OE_TEST(s.y == g_s.y);
+}
+
+void host_ocall2(MyUnion u)
+{
+    OE_TEST(u.y == g_u.y);
+}
+
+void host_ocall3(MyEnum e)
+{
+    OE_TEST(e == g_e);
+}
+
+int main(int argc, char** argv)
+{
+    oe_enclave_t* enc1 = NULL;
+    oe_enclave_t* enc2 = NULL;
+
+    const uint32_t flags = 0;
+    uint64_t global_id = OE_GLOBAL_ECALL_ID_NULL;
+    uint64_t local_id = OE_UINT64_MAX;
+    int val;
+
+    if (argc != 3)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE1_PATH ENCLAVE2_PATH\n", argv[0]);
+        return 1;
+    }
+
+    OE_TEST(
+        oe_create_enc1_enclave(
+            argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enc1) == OE_OK);
+
+    /*
+     * Use the internal APIs to test the global and local ids.
+     * At this point the expected global table should be:
+     * global id 0 - "enc_local_ecall1"
+     * global id 1 - "enc_ecall1"
+     * global id 2 - "enc_ecall2"
+     * global id 3 - "enc_ecall3"
+     * The local (per-enclave) table should be:
+     * [global id 0]: 0
+     * [global id 1]: 1
+     * [global id 2]: 2
+     * [global id 3]: 3
+     */
+    OE_TEST(
+        oe_get_global_ecall_id_by_name("enc_local_ecall1", &global_id) ==
+        OE_OK);
+    OE_TEST(global_id == 0);
+    OE_TEST(oe_get_global_ecall_id_by_name("enc_ecall1", &global_id) == OE_OK);
+    OE_TEST(global_id == 1);
+    OE_TEST(oe_get_global_ecall_id_by_name("enc_ecall2", &global_id) == OE_OK);
+    OE_TEST(global_id == 2);
+    OE_TEST(oe_get_global_ecall_id_by_name("enc_ecall3", &global_id) == OE_OK);
+    OE_TEST(global_id == 3);
+
+    /* Look up by global id. The name should not be NULL. */
+    global_id = 0;
+    OE_TEST(
+        oe_get_enclave_function_id(
+            enc1, &global_id, "enc_local_ecall1", &local_id) == OE_OK);
+    OE_TEST(local_id == 0);
+    global_id = 1;
+    OE_TEST(
+        oe_get_enclave_function_id(enc1, &global_id, "enc_ecall1", &local_id) ==
+        OE_OK);
+    OE_TEST(local_id == 1);
+    global_id = 2;
+    OE_TEST(
+        oe_get_enclave_function_id(enc1, &global_id, "enc_ecall2", &local_id) ==
+        OE_OK);
+    OE_TEST(local_id == 2);
+    global_id = 3;
+    OE_TEST(
+        oe_get_enclave_function_id(enc1, &global_id, "enc_ecall3", &local_id) ==
+        OE_OK);
+    OE_TEST(local_id == 3);
+
+    /* Look up by name. The global id will be set. */
+    global_id = OE_GLOBAL_ECALL_ID_NULL;
+    OE_TEST(
+        oe_get_enclave_function_id(
+            enc1, &global_id, "enc_local_ecall1", &local_id) == OE_OK);
+    OE_TEST(global_id == 0);
+    OE_TEST(local_id == 0);
+    global_id = OE_GLOBAL_ECALL_ID_NULL;
+    OE_TEST(
+        oe_get_enclave_function_id(enc1, &global_id, "enc_ecall1", &local_id) ==
+        OE_OK);
+    OE_TEST(global_id == 1);
+    OE_TEST(local_id == 1);
+    global_id = OE_GLOBAL_ECALL_ID_NULL;
+    OE_TEST(
+        oe_get_enclave_function_id(enc1, &global_id, "enc_ecall2", &local_id) ==
+        OE_OK);
+    OE_TEST(global_id == 2);
+    OE_TEST(local_id == 2);
+    global_id = OE_GLOBAL_ECALL_ID_NULL;
+    OE_TEST(
+        oe_get_enclave_function_id(enc1, &global_id, "enc_ecall3", &local_id) ==
+        OE_OK);
+    OE_TEST(global_id == 3);
+    OE_TEST(local_id == 3);
+
+    OE_TEST(
+        oe_create_enc2_enclave(
+            argv[2], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enc2) == OE_OK);
+
+    /*
+     * Use the internal APIs to test the global and local ids.
+     *  After creating enc2, the expected global table should be:
+     * global id 0 - "enc_local_ecall1"
+     * global id 1 - "enc_ecall1"
+     * global id 2 - "enc_ecall2"
+     * global id 3 - "enc_ecall3"
+     * global id 4 - "enc_local_ecall2"
+     * The local (per-enclave) table should be:
+     * [global id 0]: ECALL_ID_NULL
+     * [global id 1]: 2
+     * [global id 2]: 1
+     * [global id 3]: ECALL_ID_NULL
+     * [global id 4]: 0
+     */
+    OE_TEST(
+        oe_get_global_ecall_id_by_name("enc_local_ecall1", &global_id) ==
+        OE_OK);
+    OE_TEST(global_id == 0);
+    OE_TEST(oe_get_global_ecall_id_by_name("enc_ecall1", &global_id) == OE_OK);
+    OE_TEST(global_id == 1);
+    OE_TEST(oe_get_global_ecall_id_by_name("enc_ecall2", &global_id) == OE_OK);
+    OE_TEST(global_id == 2);
+    OE_TEST(oe_get_global_ecall_id_by_name("enc_ecall3", &global_id) == OE_OK);
+    OE_TEST(global_id == 3);
+    OE_TEST(
+        oe_get_global_ecall_id_by_name("enc_local_ecall2", &global_id) ==
+        OE_OK);
+    OE_TEST(global_id == 4);
+
+    /*
+     * Look up by gloal id. The name should not be NULL.
+     * The result of using "enc_local_ecall1" and "enc_ecall3" should
+     * return ECALL_ID_NULL.
+     */
+    global_id = 0;
+    OE_TEST(
+        oe_get_enclave_function_id(
+            enc2, &global_id, "enc_local_ecall1", &local_id) == OE_OK);
+    OE_TEST(local_id == OE_ECALL_ID_NULL);
+    global_id = 1;
+    OE_TEST(
+        oe_get_enclave_function_id(enc2, &global_id, "enc_ecall1", &local_id) ==
+        OE_OK);
+    OE_TEST(local_id == 2);
+    global_id = 2;
+    OE_TEST(
+        oe_get_enclave_function_id(enc2, &global_id, "enc_ecall2", &local_id) ==
+        OE_OK);
+    OE_TEST(local_id == 1);
+    global_id = 3;
+    OE_TEST(
+        oe_get_enclave_function_id(enc2, &global_id, "enc_ecall3", &local_id) ==
+        OE_OK);
+    OE_TEST(local_id == OE_ECALL_ID_NULL);
+    global_id = 4;
+    OE_TEST(
+        oe_get_enclave_function_id(
+            enc2, &global_id, "enc_local_ecall2", &local_id) == OE_OK);
+    OE_TEST(local_id == 0);
+
+    /* Look up by name. The global id will be set. */
+    global_id = OE_GLOBAL_ECALL_ID_NULL;
+    OE_TEST(
+        oe_get_enclave_function_id(
+            enc2, &global_id, "enc_local_ecall1", &local_id) == OE_OK);
+    OE_TEST(global_id == 0);
+    OE_TEST(local_id == OE_ECALL_ID_NULL);
+    global_id = OE_GLOBAL_ECALL_ID_NULL;
+    OE_TEST(
+        oe_get_enclave_function_id(enc2, &global_id, "enc_ecall1", &local_id) ==
+        OE_OK);
+    OE_TEST(global_id == 1);
+    OE_TEST(local_id == 2);
+    global_id = OE_GLOBAL_ECALL_ID_NULL;
+    OE_TEST(
+        oe_get_enclave_function_id(enc2, &global_id, "enc_ecall2", &local_id) ==
+        OE_OK);
+    OE_TEST(global_id == 2);
+    OE_TEST(local_id == 1);
+    global_id = OE_GLOBAL_ECALL_ID_NULL;
+    OE_TEST(
+        oe_get_enclave_function_id(enc2, &global_id, "enc_ecall3", &local_id) ==
+        OE_OK);
+    OE_TEST(global_id == 3);
+    OE_TEST(local_id == OE_ECALL_ID_NULL);
+    global_id = OE_GLOBAL_ECALL_ID_NULL;
+    OE_TEST(
+        oe_get_enclave_function_id(
+            enc2, &global_id, "enc_local_ecall2", &local_id) == OE_OK);
+    OE_TEST(global_id == 4);
+    OE_TEST(local_id == 0);
+
+    /* Make the normal ecalls. */
+
+    // Call functions in enclave 1.
+    OE_TEST(enc_ecall1(enc1, g_s) == OE_OK);
+    OE_TEST(enc_ecall2(enc1, g_u) == OE_OK);
+    OE_TEST(enc_ecall3(enc1, g_e) == OE_OK);
+
+    // Change values for enclave 2.
+    g_s = {8, 9};
+    g_u.y = 10;
+    OE_TEST(enc_ecall1(enc2, g_s) == OE_OK);
+    OE_TEST(enc_ecall2(enc2, g_u) == OE_OK);
+
+    OE_TEST(enc_local_ecall1(enc1, &val, 11) == OE_OK);
+    OE_TEST(val == 12);
+    OE_TEST(enc_local_ecall2(enc2, &val, 13) == OE_OK);
+    OE_TEST(val == 14);
+
+    OE_TEST(oe_terminate_enclave(enc1) == OE_OK);
+    OE_TEST(oe_terminate_enclave(enc2) == OE_OK);
+
+    printf("=== passed all tests (call_conflict)\n");
+}

--- a/test/comprehensive/host/teststring.cpp
+++ b/test/comprehensive/host/teststring.cpp
@@ -20,6 +20,8 @@ oe_result_t ecall_string_no_null_terminator_modified(
 {
     oe_result_t _result = OE_FAILURE;
 
+    static uint64_t global_id = OE_GLOBAL_ECALL_ID_NULL;
+
     /* Marshalling struct */
     ecall_string_no_null_terminator_args_t _args, *_pargs_in = NULL,
                                                   *_pargs_out = NULL;
@@ -82,7 +84,9 @@ oe_result_t ecall_string_no_null_terminator_modified(
     /* Call enclave function */
     if ((_result = oe_call_enclave_function(
              enclave,
-             all_fcn_id_ecall_string_no_null_terminator,
+             &global_id,
+             __all_ecall_info_table[all_fcn_id_ecall_string_no_null_terminator]
+                 .name,
              _input_buffer,
              _input_buffer_size,
              _output_buffer,
@@ -125,6 +129,8 @@ oe_result_t ecall_wstring_no_null_terminator_modified(
     size_t s2_len)
 {
     oe_result_t _result = OE_FAILURE;
+
+    static uint64_t global_id = OE_GLOBAL_ECALL_ID_NULL;
 
     /* Marshalling struct */
     ecall_wstring_no_null_terminator_args_t _args, *_pargs_in = NULL,
@@ -188,7 +194,9 @@ oe_result_t ecall_wstring_no_null_terminator_modified(
     /* Call enclave function */
     if ((_result = oe_call_enclave_function(
              enclave,
-             all_fcn_id_ecall_wstring_no_null_terminator,
+             &global_id,
+             __all_ecall_info_table[all_fcn_id_ecall_wstring_no_null_terminator]
+                 .name,
              _input_buffer,
              _input_buffer_size,
              _output_buffer,

--- a/test/virtual/enclave_impl.h
+++ b/test/virtual/enclave_impl.h
@@ -6,6 +6,10 @@
 
 #include <map>
 
+#define OE_ECALL_ID_NULL OE_UINT64_MAX
+/* Temporily set value. */
+#define OE_MAX_ECALLS 256
+
 typedef void (*oe_ocall_func_t)(
     const uint8_t* input_buffer,
     size_t input_buffer_size,
@@ -20,6 +24,14 @@ typedef void (*oe_ecall_func_t)(
     size_t output_buffer_size,
     size_t* output_bytes_written);
 
+/**
+ * Type of ecall information
+ */
+typedef struct _oe_ecall_id_t
+{
+    uint64_t id;
+} oe_ecall_id_t;
+
 struct _oe_enclave
 {
     oe_result_t status;
@@ -28,10 +40,14 @@ struct _oe_enclave
     uint32_t _num_ocalls;
     const oe_ecall_func_t* _ecall_table;
     uint32_t _num_ecalls;
+    oe_ecall_id_t _ecall_id_table[OE_MAX_ECALLS];
     void (*_set_enclave)(oe_enclave_t*);
     void* _lib_handle;
 
-    _oe_enclave(const oe_ocall_func_t* ocall_table, uint32_t num_ocalls)
+    _oe_enclave(
+        const oe_ocall_func_t* ocall_table,
+        uint32_t num_ocalls,
+        uint32_t num_ecalls)
     {
         status = OE_OK;
         _ocall_table = ocall_table;
@@ -40,6 +56,10 @@ struct _oe_enclave
         _num_ecalls = 0;
         _set_enclave = nullptr;
         _lib_handle = nullptr;
+        for (int i = 0; i < OE_MAX_ECALLS; i++)
+        {
+            _ecall_id_table[i].id = OE_ECALL_ID_NULL;
+        }
     }
 
     void* malloc(uint64_t size)

--- a/test/virtual/host.cpp
+++ b/test/virtual/host.cpp
@@ -8,16 +8,145 @@
 #endif
 
 #include <openenclave/edger8r/host.h>
+#include <mutex>
 
 #include "enclave_impl.h"
 
+/* Temporily set value. */
+#define OE_MAX_ECALLS 256
+
 extern "C"
 {
+    const char* _ecall_table[OE_MAX_ECALLS];
+    uint32_t _ecall_table_size;
+    std::mutex oe_lock;
     thread_local oe_enclave_t* _enclave;
+
+    // Get the global ecall id from the _ecall_table.
+    oe_result_t oe_get_global_ecall_id_by_name(
+        const char* name,
+        uint64_t* global_id)
+    {
+        oe_result_t result = OE_NOT_FOUND;
+        uint64_t i;
+
+        oe_lock.lock();
+        if (!global_id)
+        {
+            result = OE_INVALID_PARAMETER;
+            goto done;
+        }
+
+        for (i = 0; i < _ecall_table_size; i++)
+        {
+            if (strcmp(_ecall_table[i], name) == 0)
+            {
+                *global_id = i;
+                result = OE_OK;
+                break;
+            }
+        }
+
+        /* If the name is not found, adding it to the table. */
+        if (result == OE_NOT_FOUND)
+        {
+            if (_ecall_table_size >= OE_MAX_ECALLS)
+            {
+                result = OE_OUT_OF_BOUNDS;
+                goto done;
+            }
+
+            _ecall_table[_ecall_table_size] = name;
+            *global_id = _ecall_table_size;
+            _ecall_table_size++;
+            result = OE_OK;
+        }
+
+    done:
+        oe_lock.unlock();
+        return result;
+    }
+
+    oe_result_t oe_get_enclave_function_id(
+        oe_enclave_t* enclave,
+        uint64_t* global_id,
+        const char* name,
+        uint64_t* id)
+    {
+        oe_result_t result = OE_FAILURE;
+
+        if (!enclave || !global_id || !name || !id)
+        {
+            result = OE_INVALID_PARAMETER;
+            goto done;
+        }
+
+        if (*global_id == OE_GLOBAL_ECALL_ID_NULL)
+        {
+            if ((result = oe_get_global_ecall_id_by_name(name, global_id)) !=
+                OE_OK)
+                goto done;
+        }
+
+        if (*global_id >= OE_MAX_ECALLS)
+        {
+            result = OE_OUT_OF_BOUNDS;
+            goto done;
+        }
+
+        /* Look-up the ecall id from the per-enclave table. */
+        *id = enclave->_ecall_id_table[*global_id].id;
+
+        result = OE_OK;
+    done:
+
+        return result;
+    }
+
+    static oe_result_t oe_host_register_enclave_functions(
+        oe_enclave_t* enclave,
+        const oe_ecall_info_t* ecall_info_table,
+        uint32_t num_ecalls)
+    {
+        oe_result_t result = OE_UNEXPECTED;
+
+        if (!enclave)
+        {
+            result = OE_INVALID_PARAMETER;
+            goto done;
+        }
+
+        /*  Nothing to add when the table is empty, fall through. */
+        if (!ecall_info_table || !num_ecalls)
+        {
+            result = OE_OK;
+            goto done;
+        }
+
+        uint32_t i;
+        for (i = 0; i < num_ecalls; i++)
+        {
+            uint64_t global_id = OE_GLOBAL_ECALL_ID_NULL;
+            const char* name = ecall_info_table[i].name;
+            uint64_t local_id = i;
+
+            /* Assign a proper global id based on the global __ecall_table. */
+            if ((oe_get_global_ecall_id_by_name(name, &global_id)) != OE_OK)
+                continue;
+
+            enclave->_ecall_id_table[global_id].id = local_id;
+        }
+        result = OE_OK;
+
+    done:
+
+        return result;
+    }
 
     extern "C" oe_result_t oe_call_enclave_function(
         oe_enclave_t* enclave,
-        uint32_t function_id,
+        uint64_t* global_id,
+        const char* name,
         const void* input_buffer,
         size_t input_buffer_size,
         void* output_buffer,
@@ -26,15 +155,28 @@ extern "C"
     {
         oe_result_t result = OE_FAILURE;
         oe_enclave_t* previous_enclave = _enclave;
+        uint64_t function_id = OE_ECALL_ID_NULL;
         _enclave = enclave;
         enclave->_set_enclave(enclave);
 
         if (!_enclave->is_outside_enclave(input_buffer, input_buffer_size) ||
-            !_enclave->is_outside_enclave(output_buffer, output_buffer_size))
+            !_enclave->is_outside_enclave(output_buffer, output_buffer_size) ||
+            !global_id)
         {
             result = OE_INVALID_PARAMETER;
             goto done;
         }
+
+        /*
+         * Look up the function id from the per-enclave table based on the
+         * global id. The global id is defined as a static variable in the
+         * oeedger8r-generated code. The function initializes the global id in
+         * the first invocation and uses the cached global id for the subsequent
+         * invocations.
+         */
+        if (oe_get_enclave_function_id(
+                enclave, global_id, name, &function_id) != OE_OK)
+            goto done;
 
         {
             void* enc_input_buffer = enclave->malloc(input_buffer_size);
@@ -44,6 +186,11 @@ extern "C"
             size_t* enc_output_bytes_written =
                 (size_t*)enclave->malloc(sizeof(size_t));
 
+            if (function_id >= enclave->_num_ecalls)
+            {
+                result = OE_OUT_OF_BOUNDS;
+                goto done;
+            }
             enclave->_ecall_table[function_id](
                 static_cast<const uint8_t*>(enc_input_buffer),
                 input_buffer_size,
@@ -77,6 +224,8 @@ extern "C"
         uint32_t setting_count,
         const oe_ocall_func_t* ocall_table,
         uint32_t num_ocalls,
+        const oe_ecall_info_t* ecall_info_table,
+        uint32_t num_ecalls,
         oe_enclave_t** enclave)
     {
         OE_UNUSED(path);
@@ -85,7 +234,8 @@ extern "C"
         OE_UNUSED(settings);
         OE_UNUSED(setting_count);
 
-        oe_enclave_t* enc = new _oe_enclave(ocall_table, num_ocalls);
+        oe_enclave_t* enc =
+            new _oe_enclave(ocall_table, num_ocalls, num_ecalls);
         printf("Loading virtual enclave %s\n", path);
 #if _WIN32
         std::string path_with_ext = std::string(path) + ".dll";
@@ -117,6 +267,10 @@ extern "C"
                 path);
             exit(1);
         }
+
+        if (oe_host_register_enclave_functions(
+                enc, ecall_info_table, num_ecalls) != OE_OK)
+            return OE_FAILURE;
 
         enc->_lib_handle = h;
         *enclave = enc;

--- a/test/virtual/include/openenclave/edger8r/host.h
+++ b/test/virtual/include/openenclave/edger8r/host.h
@@ -64,12 +64,24 @@ OE_EXTERNC_BEGIN
  */
 oe_result_t oe_call_enclave_function(
     oe_enclave_t* enclave,
-    uint32_t function_id,
+    uint64_t* global_id,
+    const char* name,
     const void* input_buffer,
     size_t input_buffer_size,
     void* output_buffer,
     size_t output_buffer_size,
     size_t* output_bytes_written);
+
+/* OE_WEAK_ALIAS */
+#ifdef __GNUC__
+#define OE_WEAK_ALIAS(OLD, NEW) \
+    extern __typeof(OLD) NEW __attribute__((__weak__, alias(#OLD)))
+#elif _MSC_VER
+#define OE_WEAK_ALIAS(OLD, NEW) \
+    __pragma(comment(linker, "/alternatename:" #NEW "=" #OLD))
+#else
+#error OE_WEAK_ALIAS not implemented
+#endif
 
 /**
  * Placeholder.

--- a/test/virtual/include/openenclave/host.h
+++ b/test/virtual/include/openenclave/host.h
@@ -138,6 +138,11 @@ typedef struct _oe_enclave_setting
     } u;
 } oe_enclave_setting_t;
 
+typedef struct _oe_ecall_info_t
+{
+    const char* name;
+} oe_ecall_info_t;
+
 /**
  * Create an enclave from an enclave image file.
  *
@@ -180,6 +185,8 @@ oe_result_t oe_create_enclave(
     uint32_t setting_count,
     const oe_ocall_func_t* ocall_table,
     uint32_t ocall_count,
+    const oe_ecall_info_t* ecall_name_table,
+    uint32_t ecall_count,
     oe_enclave_t** enclave);
 
 /**
@@ -390,6 +397,30 @@ void oe_free_key(
     size_t key_buffer_size,
     uint8_t* key_info,
     size_t key_info_size);
+
+#define OE_GLOBAL_ECALL_ID_NULL OE_UINT64_MAX
+#define OE_ECALL_ID_NULL OE_UINT64_MAX
+
+/**
+ * Obtain the id from the global ecall table by name.
+ * Note that this is an internal API, which is exposed for the purpose of
+ * testing.
+ */
+oe_result_t oe_get_global_ecall_id_by_name(
+    const char* name,
+    uint64_t* global_id);
+
+/**
+ * Obtain the ecall id based on the global id. If the global id is not set, the
+ * name is used to add a new entry to the global ecall table and set the global
+ * id. Note that this is an internal API, which is exposed for the purpose of
+ * testing.
+ */
+oe_result_t oe_get_enclave_function_id(
+    oe_enclave_t* enclave,
+    uint64_t* global_id,
+    const char* name,
+    uint64_t* id);
 
 OE_EXTERNC_END
 


### PR DESCRIPTION
This PR prototypes the ECALL refactoring based on the [proposal](https://github.com/openenclave/openenclave/pull/3086). The idea is maintaining a global table that keeps track of ECALLs from enclaves instantiated by the host, and a per-enclave table that caches the ECALL id using the same global id.

The PR consists of three parts as follows.
- The modifications to both oeedger8r and virtual environment
   - Emit an array of ECALL name string in the `_u.c`
   ```
   /**** Trusted function names. ****/
   const oe_ecall_info_t __enc1_ecall_info_table[] = 
   {
       { "enc_ecall1" },
       { "enc_ecall2" },
       { "enc_ecall3" },
       { NULL }
   };
   ```
   - Modify the `oe_create_enclave` to pass the string array
   ```
   oe_result_t oe_create_enc1_enclave(
       const char* path,
       oe_enclave_type_t type,
       uint32_t flags,
       const oe_enclave_setting_t* settings,
       uint32_t setting_count,
       oe_enclave_t** enclave)
   {
       return oe_create_enclave(
                 path,
                 type,
                 flags,
                 settings,
                 setting_count,
                 __enc1_ocall_function_table,
                 3,
                 __enc1_ecall_info_table,
                  3,
                 enclave);
     }
     ```
   - Declare the `global_id` as a static variable in the ECALL wrapper
   ```
   static uint64_t global_id = OE_GLOBAL_ECALL_ID_NULL
   ```
   - Modify the `oe_call_enclave_function` from passing function id to global id and the name string
  ```
   /* Call enclave function. */
   if ((_result = oe_call_enclave_function(
             enclave,
             &global_id,
             __enc1_ecall_info_table[enc1_fcn_id_enc_ecall2].name,
             _input_buffer,
             _input_buffer_size,
             _output_buffer,
             _output_buffer_size,
             &_output_bytes_written)) != OE_OK)
        goto done;
  ```

- Avoid the duplicated definitions/implementations of host stub
  - Use weak alias to the ECALL wrapper implementation
  ```
  oe_result_t enc1_enc_ecall1(
     oe_enclave_t* enclave,
     MyStruct s)
  {
    ...
  }

  OE_WEAK_ALIAS(enc1_enc_ecall1, enc_ecall1);
  ```

- Add test
  - Using the same test as `prefix`, but remove the `--use-prefix` option
  - Exposing internal APIs from the virtual environment to test logic of local id/global id look-up