### PR TITLE
Support subset of C directives (#ifdef, #ifndef, #else, #endif)

### DIFF
--- a/ast.h
+++ b/ast.h
@@ -103,4 +103,12 @@ struct Edl
     std::vector<Function*> untrusted_funcs_;
 };
 
+enum Directive
+{
+    Ifdef,
+    Ifndef,
+    Else,
+    Endif,
+};
+
 #endif // AST_H

--- a/docs/Grammar.md
+++ b/docs/Grammar.md
@@ -17,6 +17,9 @@ E.g: `'{' ',' '*'`.
 
 Comments and white-spaces are assumed to be removed by the lexer.
 
+C-style preprocessor directives are defined by starting with `#`.
+E.g: `#ifdef NAME` `#else` `#endif`.
+
 In addition to keywords and operators, the lexer recognizes the following tokens
 - `identifier` A sequence of alphanumeric characters or '_' that starts with a character or '_'.
    Valid identifiers in EDL are valid C language identifiers.
@@ -53,8 +56,15 @@ enclave_item :
     | enum_declaration
     | struct_declaration
     | union_declaration
+    | preprocessor_directive
     | trusted_section
     | untrusted_section
+
+preprocessor_directive:
+  "#" "ifdef" identifier
+  | "#" "ifndef" identifier
+  | "#" "else"
+  | "#" "endif"
 
 include_statement: "include" string
 
@@ -132,7 +142,7 @@ pointer =
 
 array_dimension = '[' (integer | identifier) ']'
 
-trusted_section = "trusted" '{' trusted_function* '}' ';'
+trusted_section = "trusted" '{' (trusted_function|preprocessor_directive)* '}' ';'
 
 trusted_function =
     "public" function_declaration [allow_list] [trusted_suffixes] ';'
@@ -140,7 +150,7 @@ trusted_function =
 allow_list = "allow" '(' identifier_list ')'
 
 untrusted_section =
-    "untrusted" '{' untrusted_function* '}' [untrusted_suffixes] ';'
+    "untrusted" '{' (untrusted_function|preprocessor_directive)* '}' [untrusted_suffixes] ';'
 
 function_declaration = atype identifier parameter_list
 
@@ -153,5 +163,32 @@ trusted_suffixes = "transition_using_threads"
 
 untrusted_suffixes = "transition_using_threads" | "propagate_errno"
 
+
+```
+
+### C-style Preprocessor Directives
+
+```c
+
+conditional:
+    if_directive identifier statement* [else_directive statement*] endif_directive
+
+if_directive:
+  "#" "ifdef"
+  | "#" "ifndef"
+
+else_directive: "#" "else"
+
+endif_directive: "#" "endif"
+
+statement =
+    include_statement
+    | import_statement
+    | from_import_statement
+    | enum_declaration
+    | struct_declaration
+    | union_declaration
+    | trusted_function
+    | untrusted_function
 
 ```

--- a/lexer.cpp
+++ b/lexer.cpp
@@ -124,6 +124,7 @@ Token Lexer::next()
         case ',':
         case ';':
         case '=':
+        case '#':
         {
             Token t = {line_, col_, p_, p_ + 1};
             p_++;

--- a/main.cpp
+++ b/main.cpp
@@ -40,6 +40,8 @@ const char* usage =
     "--trusted             Generate trusted proxy and bridge\n"
     "--untrusted-dir <dir> Specify the directory for saving untrusted code\n"
     "--trusted-dir   <dir> Specify the directory for saving trusted code\n"
+    "-D<name>              Define the name to be used by the C-style "
+    "preprocessor\n"
     "--experimental        Enable experimental features\n"
     "--help                Print this help message\n"
     "\n"
@@ -55,6 +57,7 @@ int main(int argc, char** argv)
     std::string untrusted_dir = ".";
     std::string trusted_dir = ".";
     std::vector<std::string> files;
+    std::vector<std::string> defines;
     int i = 1;
 
     if (argc == 1)
@@ -95,6 +98,17 @@ int main(int argc, char** argv)
             untrusted_dir = get_dir(i++);
         else if (a == "--experimental")
             ;
+        else if (a.rfind("-D", 0) == 0)
+        {
+            std::string define = a.substr(2);
+            if (define.empty())
+            {
+                fprintf(stderr, "error: macro name missing after '-D'\n");
+                fprintf(stderr, "%s", usage);
+                return -1;
+            }
+            defines.push_back(define);
+        }
         else if (a == "--help")
         {
             printf("%s\n", usage);
@@ -131,7 +145,7 @@ int main(int argc, char** argv)
 
     for (std::string& file : files)
     {
-        Parser p(file, searchpaths);
+        Parser p(file, searchpaths, defines);
         Edl* edl = p.parse();
 
         if (gen_trusted)

--- a/parser.h
+++ b/parser.h
@@ -11,6 +11,7 @@
 #include "ast.h"
 #include "lexer.h"
 #include "parser.h"
+#include "preprocessor.h"
 
 class Parser
 {
@@ -20,6 +21,7 @@ class Parser
     std::string filename_;
     std::string basename_;
     std::vector<std::string> searchpaths_;
+    std::vector<std::string> defines_;
 
     Lexer* lex_;
     Token t_;
@@ -33,6 +35,8 @@ class Parser
     std::vector<Function*> untrusted_funcs_;
     std::vector<Function*> imported_trusted_funcs_;
     std::vector<Function*> imported_untrusted_funcs_;
+
+    Preprocessor pp_;
 
   private:
     Token next();
@@ -58,6 +62,8 @@ class Parser
     Type* parse_atype2(Token t);
     Dims* parse_dims();
 
+    void parse_directive();
+
   private:
     void append_include(const std::string& inc);
     void append_type(UserType* type);
@@ -79,7 +85,8 @@ class Parser
   public:
     Parser(
         const std::string& filename,
-        const std::vector<std::string>& searchpaths);
+        const std::vector<std::string>& searchpaths,
+        const std::vector<std::string>& defines);
     ~Parser();
 
     Edl* parse();

--- a/preprocessor.h
+++ b/preprocessor.h
@@ -1,0 +1,135 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef PREPROCESSOR_H
+#define PREPROCESSOR_H
+
+#include <string>
+#include <vector>
+
+#include "ast.h"
+
+struct DirectiveState
+{
+    Directive command;
+    bool condition;
+
+    DirectiveState(Directive command_, bool condition_)
+    {
+        command = command_;
+        condition = condition_;
+    }
+};
+
+class Preprocessor
+{
+    std::vector<DirectiveState> stack_;
+    const std::vector<std::string> defines_;
+
+  public:
+    Preprocessor(const std::vector<std::string>& defines) : defines_(defines)
+    {
+    }
+
+    ~Preprocessor()
+    {
+        stack_.clear();
+    }
+
+    bool process(Directive cmd, const std::string& arg = "")
+    {
+        bool result = false;
+
+        switch (cmd)
+        {
+            case Ifdef:
+            {
+                DirectiveState state(cmd, false);
+                if (is_defined(arg))
+                    state.condition = true;
+
+                stack_.push_back(state);
+                result = true;
+                break;
+            }
+            case Ifndef:
+            {
+                DirectiveState state(cmd, false);
+                if (!is_defined(arg))
+                    state.condition = true;
+
+                stack_.push_back(state);
+                result = true;
+                break;
+            }
+            case Else:
+            {
+                DirectiveState& current_state = stack_.back();
+                /* Verify that the current state is ifdef or ifndef. */
+                if (current_state.command != Ifdef &&
+                    current_state.command != Ifndef)
+                    break;
+
+                current_state.command = cmd;
+                current_state.condition = !current_state.condition;
+                result = true;
+                break;
+            }
+            case Endif:
+            {
+                /* Ensure the stack is not empty. */
+                if (stack_.empty())
+                    break;
+
+                DirectiveState& current_state = stack_.back();
+                /* Verify that the current state is ifdef, ifndef, or else. */
+                if (current_state.command != Ifdef &&
+                    current_state.command != Ifndef &&
+                    current_state.command != Else)
+                    break;
+
+                stack_.pop_back();
+                result = true;
+                break;
+            }
+            default:
+            {
+                /* Do nothing. */
+            }
+        }
+
+        return result;
+    }
+
+    bool is_defined(const std::string& name)
+    {
+        bool found = false;
+        for (auto& define : defines_)
+        {
+            if (name == define)
+            {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+
+    /* Determine if the code needs to be included based on the state of
+     * preprocessor. */
+    bool is_included()
+    {
+        if (stack_.empty() || stack_.back().condition)
+            return true;
+
+        return false;
+    }
+
+    /* Determine if there is an open control block. */
+    bool is_closed()
+    {
+        return stack_.empty();
+    }
+};
+
+#endif // PREPROCESSOR_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(cmdline)
 add_subdirectory(comprehensive)
 add_subdirectory(import)
 add_subdirectory(prefix)
+add_subdirectory(preprocessor)
 
 # Virtual Mode execution for tests.
 add_subdirectory(virtual)

--- a/test/preprocessor/CMakeLists.txt
+++ b/test/preprocessor/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_subdirectory(enc)
+add_subdirectory(host)
+
+add_test(oeedger8r_preprocessor host/oeedger8r_preprocessor_host
+         enc/oeedger8r_preprocessor_enc)

--- a/test/preprocessor/edl/else_ecall.edl
+++ b/test/preprocessor/edl/else_ecall.edl
@@ -1,0 +1,12 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+#ifdef TEST_IF_ECALL
+    public int enc_ifdef_else_ecall(int magic);
+#else
+    public int enc_else_ecall(int magic);
+#endif
+  };
+};

--- a/test/preprocessor/edl/else_enum.edl
+++ b/test/preprocessor/edl/else_enum.edl
@@ -1,0 +1,26 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifdef TEST_IF_ENUM
+  enum TestIfEnum {
+    Test_If_Enum_1,
+    Test_If_Enum_2,
+    Test_If_Enum_3
+  };
+#else
+  enum TestElseEnum {
+    Test_Else_Enum_1,
+    Test_Else_Enum_2,
+    Test_Else_Enum_3
+  };
+#endif
+
+  trusted {
+#ifdef TEST_IF_ENUM
+    public int enc_if_enum(TestIfEnum value);
+#else
+    public int enc_else_enum(TestElseEnum value);
+#endif
+  };
+};

--- a/test/preprocessor/edl/else_import.edl
+++ b/test/preprocessor/edl/else_import.edl
@@ -1,0 +1,10 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifdef TEST_IF_IMPORT
+  import "import_4.edl"
+#else
+  import "import_5.edl"
+#endif
+};

--- a/test/preprocessor/edl/else_ocall.edl
+++ b/test/preprocessor/edl/else_ocall.edl
@@ -1,0 +1,19 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+#ifdef TEST_IF_OCALL
+    public void enc_if_ocall();
+#else
+    public void enc_else_ocall();
+#endif
+  };
+  untrusted {
+#ifdef TEST_IF_OCALL
+    int host_if_ocall(int magic);
+#else
+    int host_else_ocall(int magic);
+#endif
+  };
+};

--- a/test/preprocessor/edl/else_struct.edl
+++ b/test/preprocessor/edl/else_struct.edl
@@ -1,0 +1,24 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifdef TEST_IF_STRUCT
+  struct TestIfStruct {
+    int num;
+    char c;
+  };
+#else
+  struct TestElseStruct {
+    int num;
+    char c;
+  };
+#endif
+
+  trusted {
+#ifdef TEST_IF_STRUCT
+    public int enc_if_struct(TestIfStruct st);
+#else
+    public int enc_else_struct(TestElseStruct st);
+#endif
+  };
+};

--- a/test/preprocessor/edl/ifdef_ecall.edl
+++ b/test/preprocessor/edl/ifdef_ecall.edl
@@ -1,0 +1,10 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+#ifdef TEST_ECALL
+    public int enc_ifdef_ecall(int magic);
+#endif
+  };
+};

--- a/test/preprocessor/edl/ifdef_enum.edl
+++ b/test/preprocessor/edl/ifdef_enum.edl
@@ -1,0 +1,18 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifdef TEST_ENUM
+  enum TestEnum {
+    Test_Enum_1,
+    Test_Enum_2,
+    Test_Enum_3
+  };
+#endif
+
+  trusted {
+#ifdef TEST_ENUM
+    public int enc_ifdef_enum(TestEnum value);
+#endif
+  };
+};

--- a/test/preprocessor/edl/ifdef_import.edl
+++ b/test/preprocessor/edl/ifdef_import.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifdef TEST_IMPORT
+  import "import_1.edl"
+#endif
+};

--- a/test/preprocessor/edl/ifdef_import_from.edl
+++ b/test/preprocessor/edl/ifdef_import_from.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifdef TEST_IMPORT_FROM
+  from "import_3.edl" import enc_import_5;
+#endif
+};

--- a/test/preprocessor/edl/ifdef_import_from_all.edl
+++ b/test/preprocessor/edl/ifdef_import_from_all.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifdef TEST_IMPORT_FROM_ALL
+  from "import_2.edl" import *;
+#endif
+};

--- a/test/preprocessor/edl/ifdef_ocall.edl
+++ b/test/preprocessor/edl/ifdef_ocall.edl
@@ -1,0 +1,15 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+#ifdef TEST_OCALL
+    public void enc_ifdef_ocall();
+#endif
+  };
+  untrusted {
+#ifdef TEST_OCALL
+    int host_ifdef_ocall(int magic);
+#endif
+  };
+};

--- a/test/preprocessor/edl/ifdef_struct.edl
+++ b/test/preprocessor/edl/ifdef_struct.edl
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifdef TEST_STRUCT
+  struct TestStruct {
+    int num;
+    char c;
+  };
+#endif
+
+  trusted {
+#ifdef TEST_STRUCT
+    public int enc_ifdef_struct(TestStruct st);
+#endif
+  };
+};

--- a/test/preprocessor/edl/ifndef_ecall.edl
+++ b/test/preprocessor/edl/ifndef_ecall.edl
@@ -1,0 +1,10 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+#ifndef TEST_ECALL
+    public int enc_ifndef_ecall(int magic);
+#endif
+  };
+};

--- a/test/preprocessor/edl/ifndef_enum.edl
+++ b/test/preprocessor/edl/ifndef_enum.edl
@@ -1,0 +1,18 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifndef TEST_ENUM
+  enum TestDefEnum {
+    Test_Def_Enum_1,
+    Test_Def_Enum_2,
+    Test_Def_Enum_3
+  };
+#endif
+
+  trusted {
+#ifndef TEST_ENUM
+    public int enc_ifndef_enum(TestDefEnum value);
+#endif
+  };
+};

--- a/test/preprocessor/edl/ifndef_import.edl
+++ b/test/preprocessor/edl/ifndef_import.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifndef TEST_IMPORT
+  import "import_6.edl"
+#endif
+};

--- a/test/preprocessor/edl/ifndef_ocall.edl
+++ b/test/preprocessor/edl/ifndef_ocall.edl
@@ -1,0 +1,15 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+#ifndef TEST_OCALL
+    public void enc_ifndef_ocall();
+#endif
+  };
+  untrusted {
+#ifndef TEST_OCALL
+    int host_ifndef_ocall(int magic);
+#endif
+  };
+};

--- a/test/preprocessor/edl/ifndef_struct.edl
+++ b/test/preprocessor/edl/ifndef_struct.edl
@@ -1,0 +1,17 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+#ifndef TEST_STRUCT
+  struct TestDefStruct {
+    int num;
+    char c;
+  };
+#endif
+
+  trusted {
+#ifndef TEST_STRUCT
+    public int enc_ifndef_struct(TestDefStruct st);
+#endif
+  };
+};

--- a/test/preprocessor/edl/import_1.edl
+++ b/test/preprocessor/edl/import_1.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    public int enc_import_1(int magic);
+    public int enc_import_2(int magic);
+  };
+};

--- a/test/preprocessor/edl/import_2.edl
+++ b/test/preprocessor/edl/import_2.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    public int enc_import_3(int magic);
+    public int enc_import_4(int magic);
+  };
+};

--- a/test/preprocessor/edl/import_3.edl
+++ b/test/preprocessor/edl/import_3.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    public int enc_import_5(int magic);
+    public int enc_import_6(int magic);
+  };
+};

--- a/test/preprocessor/edl/import_4.edl
+++ b/test/preprocessor/edl/import_4.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    public int enc_import_7(int magic);
+    public int enc_import_8(int magic);
+  };
+};

--- a/test/preprocessor/edl/import_5.edl
+++ b/test/preprocessor/edl/import_5.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    public int enc_import_9(int magic);
+  };
+};

--- a/test/preprocessor/edl/import_6.edl
+++ b/test/preprocessor/edl/import_6.edl
@@ -1,0 +1,8 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    public int enc_import_10(int magic);
+  };
+};

--- a/test/preprocessor/edl/preprocessor.edl
+++ b/test/preprocessor/edl/preprocessor.edl
@@ -1,0 +1,22 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave {
+  import "ifdef_ecall.edl"
+  import "ifdef_enum.edl"
+  import "ifdef_ocall.edl"
+  import "ifdef_struct.edl"
+  import "ifdef_import.edl"
+  import "ifdef_import_from_all.edl"
+  import "ifdef_import_from.edl"
+  import "ifndef_ecall.edl"
+  import "ifndef_enum.edl"
+  import "ifndef_ocall.edl"
+  import "ifndef_struct.edl"
+  import "ifndef_import.edl"
+  import "else_ecall.edl"
+  import "else_enum.edl"
+  import "else_ocall.edl"
+  import "else_struct.edl"
+  import "else_import.edl"
+};

--- a/test/preprocessor/enc/CMakeLists.txt
+++ b/test/preprocessor/enc/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+add_custom_command(
+  OUTPUT preprocessor_args.h preprocessor_t.h preprocessor_t.c
+  COMMAND
+    oeedger8r --trusted -DTEST_ECALL -DTEST_ENUM -DTEST_OCALL -DTEST_STRUCT
+    -DTEST_IMPORT -DTEST_IMPORT_FROM_ALL -DTEST_IMPORT_FROM --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../edl preprocessor.edl)
+
+add_library(oeedger8r_preprocessor_enc SHARED preprocessor_t.c enc.cpp)
+
+target_include_directories(oeedger8r_preprocessor_enc
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(oeedger8r_preprocessor_enc oeedger8r_test_enclave)
+
+set_target_properties(oeedger8r_preprocessor_enc PROPERTIES PREFIX "")

--- a/test/preprocessor/enc/enc.cpp
+++ b/test/preprocessor/enc/enc.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/tests.h>
+#include "preprocessor_t.h"
+
+#include <stdio.h>
+
+int enc_import_1(int magic)
+{
+    OE_TEST(magic == 10);
+    return 11;
+}
+
+int enc_import_2(int magic)
+{
+    OE_TEST(magic == 20);
+    return 21;
+}
+
+int enc_import_3(int magic)
+{
+    OE_TEST(magic == 30);
+    return 31;
+}
+
+int enc_import_4(int magic)
+{
+    OE_TEST(magic == 40);
+    return 41;
+}
+
+int enc_import_5(int magic)
+{
+    OE_TEST(magic == 50);
+    return 51;
+}
+
+int enc_import_9(int magic)
+{
+    OE_TEST(magic == 90);
+    return 91;
+}
+
+void enc_ifdef_ocall()
+{
+    int ret_val = -1;
+    OE_TEST(host_ifdef_ocall(&ret_val, 3) == OE_OK);
+    OE_TEST(ret_val == 4);
+}
+
+int enc_ifdef_ecall(int magic)
+{
+    OE_TEST(magic = 5);
+    return 6;
+}
+
+int enc_ifdef_enum(TestEnum value)
+{
+    OE_TEST(value == Test_Enum_2);
+    return 7;
+}
+
+int enc_ifdef_struct(TestStruct st)
+{
+    OE_TEST(st.num == 8);
+    OE_TEST(st.c == 9);
+    return 10;
+}
+
+void enc_else_ocall()
+{
+    int ret_val = -1;
+    OE_TEST(host_else_ocall(&ret_val, 3) == OE_OK);
+    OE_TEST(ret_val == 4);
+}
+
+int enc_else_ecall(int magic)
+{
+    OE_TEST(magic = 5);
+    return 6;
+}
+
+int enc_else_enum(TestElseEnum value)
+{
+    OE_TEST(value == Test_Else_Enum_3);
+    return 7;
+}
+
+int enc_else_struct(TestElseStruct st)
+{
+    OE_TEST(st.num == 8);
+    OE_TEST(st.c == 9);
+    return 10;
+}

--- a/test/preprocessor/host/CMakeLists.txt
+++ b/test/preprocessor/host/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) Open Enclave SDK contributors. Licensed under the MIT License.
+
+add_custom_command(
+  OUTPUT preprocessor_args.h preprocessor_u.h preprocessor_u.c
+  COMMAND
+    oeedger8r --untrusted -DTEST_ECALL -DTEST_ENUM -DTEST_OCALL -DTEST_STRUCT
+    -DTEST_IMPORT -DTEST_IMPORT_FROM_ALL -DTEST_IMPORT_FROM --search-path
+    ${CMAKE_CURRENT_SOURCE_DIR}/../edl preprocessor.edl)
+
+add_executable(oeedger8r_preprocessor_host preprocessor_u.c host.cpp)
+
+target_include_directories(oeedger8r_preprocessor_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(oeedger8r_preprocessor_host oeedger8r_test_host)

--- a/test/preprocessor/host/host.cpp
+++ b/test/preprocessor/host/host.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#include <stdio.h>
+
+#include <openenclave/internal/tests.h>
+#include "preprocessor_u.h"
+
+int host_ifdef_ocall(int magic)
+{
+    OE_TEST(magic == 3);
+    return 4;
+}
+
+int host_else_ocall(int magic)
+{
+    OE_TEST(magic == 3);
+    return 4;
+}
+
+int main(int argc, char** argv)
+{
+    oe_enclave_t* enclave = NULL;
+
+    const uint32_t flags = 0;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        return 1;
+    }
+
+    OE_TEST(
+        oe_create_preprocessor_enclave(
+            argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave) == OE_OK);
+
+    int ret_val = -1;
+    // import "import_1.edl"
+    OE_TEST(enc_import_1(enclave, &ret_val, 10) == OE_OK);
+    OE_TEST(ret_val == 11);
+
+    OE_TEST(enc_import_2(enclave, &ret_val, 20) == OE_OK);
+    OE_TEST(ret_val == 21);
+
+    // from "import_2.edl" import *;
+    OE_TEST(enc_import_3(enclave, &ret_val, 30) == OE_OK);
+    OE_TEST(ret_val == 31);
+
+    OE_TEST(enc_import_4(enclave, &ret_val, 40) == OE_OK);
+    OE_TEST(ret_val == 41);
+
+    // from "import_3.edl" import enc_import_5;
+    OE_TEST(enc_import_5(enclave, &ret_val, 50) == OE_OK);
+    OE_TEST(ret_val == 51);
+
+    // import "import_5.edl"
+    OE_TEST(enc_import_9(enclave, &ret_val, 90) == OE_OK);
+    OE_TEST(ret_val == 91);
+
+    OE_TEST(enc_ifdef_ocall(enclave) == OE_OK);
+
+    OE_TEST(enc_ifdef_ecall(enclave, &ret_val, 5) == OE_OK);
+    OE_TEST(ret_val == 6);
+
+    OE_TEST(enc_ifdef_enum(enclave, &ret_val, Test_Enum_2) == OE_OK);
+    OE_TEST(ret_val == 7);
+
+    TestStruct ts;
+    ts.num = 8;
+    ts.c = 9;
+    OE_TEST(enc_ifdef_struct(enclave, &ret_val, ts) == OE_OK);
+    OE_TEST(ret_val == 10);
+
+    OE_TEST(enc_else_ocall(enclave) == OE_OK);
+
+    OE_TEST(enc_else_ecall(enclave, &ret_val, 5) == OE_OK);
+    OE_TEST(ret_val == 6);
+
+    OE_TEST(enc_else_enum(enclave, &ret_val, Test_Else_Enum_3) == OE_OK);
+    OE_TEST(ret_val == 7);
+
+    TestElseStruct elsets;
+    elsets.num = 8;
+    elsets.c = 9;
+    OE_TEST(enc_else_struct(enclave, &ret_val, elsets) == OE_OK);
+    OE_TEST(ret_val == 10);
+
+    OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+
+    printf("=== passed all tests (preprocessor)\n");
+}


### PR DESCRIPTION
Following the discussion from #9, this PR implements the support of the subset of C directives (#ifdef, #ifndef, #else, #endif) that is sufficient for our current needs. Also, the implementation allows us to get the correct line in the file when there is errors.

This implementation assumes that the #ifdef and #ifndef shouldn't be used across regions, which are defined as follows.
```
enclave {
  [region 1: include, import, enum, struct]
  trusted {
  [region 2: ecall]
  };
  untrusted {
  [region 3: ocall]
  };
};
```

Also, adding test cases to test various scenarios.