### PR TITLE
Preprocessor operates atop lexer

### DIFF
--- a/docs/Grammar.md
+++ b/docs/Grammar.md
@@ -56,15 +56,8 @@ enclave_item :
     | enum_declaration
     | struct_declaration
     | union_declaration
-    | preprocessor_directive
     | trusted_section
     | untrusted_section
-
-preprocessor_directive:
-  "#" "ifdef" identifier
-  | "#" "ifndef" identifier
-  | "#" "else"
-  | "#" "endif"
 
 include_statement: "include" string
 
@@ -142,7 +135,7 @@ pointer =
 
 array_dimension = '[' (integer | identifier) ']'
 
-trusted_section = "trusted" '{' (trusted_function|preprocessor_directive)* '}' ';'
+trusted_section = "trusted" '{' trusted_function* '}' ';'
 
 trusted_function =
     "public" function_declaration [allow_list] [trusted_suffixes] ';'
@@ -150,7 +143,7 @@ trusted_function =
 allow_list = "allow" '(' identifier_list ')'
 
 untrusted_section =
-    "untrusted" '{' (untrusted_function|preprocessor_directive)* '}' [untrusted_suffixes] ';'
+    "untrusted" '{' untrusted_function* '}' [untrusted_suffixes] ';'
 
 function_declaration = atype identifier parameter_list
 

--- a/parser.h
+++ b/parser.h
@@ -39,6 +39,7 @@ class Parser
     Preprocessor pp_;
 
   private:
+    Token get_preprocessed_token();
     Token next();
     Token peek();
     Token peek1();
@@ -61,8 +62,6 @@ class Parser
     Type* parse_atype1(Token t);
     Type* parse_atype2(Token t);
     Dims* parse_dims();
-
-    void parse_directive();
 
   private:
     void append_include(const std::string& inc);

--- a/test/preprocessor/edl/complex.edl
+++ b/test/preprocessor/edl/complex.edl
@@ -1,0 +1,24 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifdef COMPLEX1
+enclave {
+#endif
+
+trusted # ifdef COMPLEX2 {
+    public void #ifdef COMPLEX3 enc_complex_ecall1 #endif (
+           [in #ifdef COMPLEX3 , count=arg2 #endif] int* arg1
+#ifdef COMPLEX4
+                , int arg2
+#ifdef COMPLEX5
+                , int arg3
+#endif
+#endif
+        );
+# endif
+};
+
+#ifdef COMPLEX1
+}
+#endif
+;

--- a/test/preprocessor/edl/preprocessor.edl
+++ b/test/preprocessor/edl/preprocessor.edl
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 enclave {
+  import "complex.edl"
   import "ifdef_ecall.edl"
   import "ifdef_enum.edl"
   import "ifdef_ocall.edl"

--- a/test/preprocessor/enc/CMakeLists.txt
+++ b/test/preprocessor/enc/CMakeLists.txt
@@ -7,7 +7,8 @@ add_custom_command(
     oeedger8r --trusted -DTEST_ECALL -DTEST_ENUM -DTEST_OCALL -DTEST_STRUCT
     -DTEST_NESTED_IFDEF_ECALL -DTEST_IMPORT -DTEST_IMPORT_FROM_ALL
     -DTEST_IMPORT_FROM --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl
-    preprocessor.edl)
+    # Definitions for complex preprocessor usage
+    -DCOMPLEX1 -DCOMPLEX2 -DCOMPLEX3 -DCOMPLEX4 preprocessor.edl)
 
 add_library(oeedger8r_preprocessor_enc SHARED preprocessor_t.c enc.cpp)
 

--- a/test/preprocessor/enc/enc.cpp
+++ b/test/preprocessor/enc/enc.cpp
@@ -99,3 +99,9 @@ int enc_nested_ifdef_ecall(int magic)
     OE_TEST(magic == 123);
     return 456;
 }
+
+void enc_complex_ecall1(int* a, int n)
+{
+    OE_TEST(*a == 1);
+    OE_TEST(n == 1);
+}

--- a/test/preprocessor/host/CMakeLists.txt
+++ b/test/preprocessor/host/CMakeLists.txt
@@ -6,7 +6,8 @@ add_custom_command(
     oeedger8r --untrusted -DTEST_ECALL -DTEST_ENUM -DTEST_OCALL -DTEST_STRUCT
     -DTEST_NESTED_IFDEF_ECALL -DTEST_IMPORT -DTEST_IMPORT_FROM_ALL
     -DTEST_IMPORT_FROM --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl
-    preprocessor.edl)
+    # Definitions for complex preprocessor usage
+    -DCOMPLEX1 -DCOMPLEX2 -DCOMPLEX3 -DCOMPLEX4 preprocessor.edl)
 
 add_executable(oeedger8r_preprocessor_host preprocessor_u.c host.cpp)
 

--- a/test/preprocessor/host/host.cpp
+++ b/test/preprocessor/host/host.cpp
@@ -88,6 +88,10 @@ int main(int argc, char** argv)
     OE_TEST(enc_nested_ifdef_ecall(enclave, &ret_val, 123) == OE_OK);
     OE_TEST(ret_val == 456);
 
+    // Exercise complex preprocessor usage.
+    int p = 1;
+    OE_TEST(enc_complex_ecall1(enclave, &p, p) == OE_OK);
+
     OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
 
     printf("=== passed all tests (preprocessor)\n");


### PR DESCRIPTION
Preprocessor is placed between the parser and the lexer, similar to
how a C preprocessor works.
This allows preprocessing directives to be placed anywhere in the EDL file.

Implementation
- Parser fetches tokens via the preprocessor rather than from the lexer.
- When a preprocessor directive is encountered, then all the tokens
  are skipped until is_included predicate returns true.
  The parser does not see any skipped tokens.
- Preprocessor directives pairs are not expected to span multiple edl files.
  is_closed predicate must be true when a file is parsed.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>