### PR TITLE
Add test for enum/external macro as array dimensions.

### DIFF
--- a/test/comprehensive/edl/array.edl
+++ b/test/comprehensive/edl/array.edl
@@ -351,4 +351,20 @@ enclave  {
 
         void ocall_array_assert_all_called();
     };
+
+
+    include "mytypes.h"
+    enum my_type {
+        IV_SIZE = 16
+    };
+
+
+    trusted {
+        public void ecall_named_dims(uint8_t data1[IV_SIZE], uint8_t data2[EXT_IV_SIZE]);
+    };
+
+    untrusted {
+        void ocall_named_dims(uint8_t data1[IV_SIZE], uint8_t data2[EXT_IV_SIZE]);
+    };
+
 };

--- a/test/comprehensive/enc/testarray.cpp
+++ b/test/comprehensive/enc/testarray.cpp
@@ -6,6 +6,7 @@
 #include <openenclave/enclave.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
+#include <string.h>
 #include <algorithm>
 #include "all_t.h"
 
@@ -87,6 +88,18 @@ void test_array_edl_ocalls()
     test_ocall_array_fun<unsigned long long>(ocall_array_unsigned_long_long);
 
     OE_TEST(ocall_array_assert_all_called() == OE_OK);
+
+    {
+        uint8_t data1[IV_SIZE];
+        for (uint32_t i = 0; i < IV_SIZE; ++i)
+            data1[i] = i;
+        uint8_t data2[EXT_IV_SIZE];
+        for (uint32_t i = 0; i < EXT_IV_SIZE; ++i)
+            data2[i] = i;
+
+        OE_TEST(ocall_named_dims(data1, data2) == OE_OK);
+    }
+
     printf("=== test_array_edl_ocalls passed\n");
 }
 
@@ -356,4 +369,13 @@ void ecall_array_assert_all_called()
     }
 
     OE_TEST(num_ecalls == expected_num_calls);
+}
+
+void ecall_named_dims(uint8_t data1[IV_SIZE], uint8_t data2[EXT_IV_SIZE])
+{
+    for (uint32_t i = 0; i < IV_SIZE; ++i)
+        OE_TEST(data1[i] == i);
+
+    for (uint32_t i = 0; i < EXT_IV_SIZE; ++i)
+        OE_TEST(data2[i] == i);
 }

--- a/test/comprehensive/host/testarray.cpp
+++ b/test/comprehensive/host/testarray.cpp
@@ -85,6 +85,18 @@ void test_array_edl_ecalls(oe_enclave_t* enclave)
         enclave, ecall_array_unsigned_long_long);
 
     OE_TEST(ecall_array_assert_all_called(enclave) == OE_OK);
+
+    {
+        uint8_t data1[IV_SIZE];
+        for (uint32_t i = 0; i < IV_SIZE; ++i)
+            data1[i] = i;
+        uint8_t data2[EXT_IV_SIZE];
+        for (uint32_t i = 0; i < EXT_IV_SIZE; ++i)
+            data2[i] = i;
+
+        OE_TEST(ecall_named_dims(enclave, data1, data2) == OE_OK);
+    }
+
     printf("=== test_array_edl_ecalls passed\n");
 }
 
@@ -349,4 +361,13 @@ void ocall_array_assert_all_called()
     }
 
     OE_TEST(num_ocalls == expected_num_calls);
+}
+
+void ocall_named_dims(uint8_t data1[IV_SIZE], uint8_t data2[EXT_IV_SIZE])
+{
+    for (uint32_t i = 0; i < IV_SIZE; ++i)
+        OE_TEST(data1[i] == i);
+
+    for (uint32_t i = 0; i < EXT_IV_SIZE; ++i)
+        OE_TEST(data2[i] == i);
 }

--- a/test/comprehensive/mytypes.h
+++ b/test/comprehensive/mytypes.h
@@ -12,3 +12,5 @@ typedef struct
 typedef my_type1* my_type2;
 
 typedef my_type1 my_type3[10];
+
+#define EXT_IV_SIZE 17


### PR DESCRIPTION
This locks down the solution for the issue mentioned in https://github.com/openenclave/openenclave/issues/2431

Enums and externally defined macros can be used as array dimension in oeedger8r.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>