### PR TITLE
Add missing #include <string>

### DIFF
--- a/test/virtual/host.cpp
+++ b/test/virtual/host.cpp
@@ -9,6 +9,7 @@
 
 #include <openenclave/edger8r/host.h>
 #include <mutex>
+#include <string>
 
 #include "enclave_impl.h"
 


### PR DESCRIPTION
In GCC and clang `#include <mutex>` also made std::string available.
This may not be the case in all compilers.

fixes #39

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>