### PR TITLE
Add missing #include.

### DIFF
--- a/test/virtual/host.cpp
+++ b/test/virtual/host.cpp
@@ -7,6 +7,8 @@
 #include <dlfcn.h>
 #endif
 
+#include <string>
+
 #include <openenclave/edger8r/host.h>
 
 #include "enclave_impl.h"


### PR DESCRIPTION
VS2019 complained about std::string.