### PR TITLE
Fix TOCTOU pattern for string copy in ocalls

### DIFF
--- a/w_emitter.h
+++ b/w_emitter.h
@@ -538,23 +538,21 @@ class WEmitter
                 std::string size = psize(p, "_args.");
                 std::string cmd = p->attrs_->inout_ ? "OE_READ_IN_OUT_PARAM"
                                                     : "OE_READ_OUT_PARAM";
-                if (p->attrs_->string_ || p->attrs_->wstring_)
-                {
-                    out() << "    " + check +
-                                 (p->attrs_->wstring_ ? "_WIDE(" : "(") +
-                                 "_output_buffer + _output_buffer_offset, "
-                                 "_args." +
-                                 p->name_ + "_len);";
-                }
                 UserType* ut = get_user_type_for_deep_copy(edl_, p);
                 if (!ut)
                 {
                     out() << "    " + cmd + "(" + p->name_ + ", (size_t)(" +
                                  size + "));";
-                    continue;
+                }
+                if (p->attrs_->string_ || p->attrs_->wstring_)
+                {
+                    out() << "    " + check +
+                                 (p->attrs_->wstring_ ? "_WIDE(" : "(") +
+                                 p->name_ + ", _args." + p->name_ + "_len);";
                 }
 
-                unmarshal_deep_copy(p, "", "    ", cmd, 1);
+                if (ut)
+                    unmarshal_deep_copy(p, "", "    ", cmd, 1);
             }
         }
         if (empty)


### PR DESCRIPTION
The PR fixes TOCTOU pattern of checking the null terminator of a host controlled string before copying the string into an enclave. This fix is reverting the order of the checking and copying.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>