### PR TITLE
Disable deepcopy for out parameters

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1183,6 +1183,19 @@ void Parser::validate_attributes(Decl* d)
                         atype_str(type).c_str());
                 }
             }
+
+            if (d->type_->tag_ == Ptr)
+            {
+                UserType* ut = get_user_type_for_deep_copy(types_, d);
+                if (ut)
+                {
+                    if (in_function_ && attrs->out_)
+                        ERROR_AT(
+                            itr.second,
+                            "`out' is invalid for user defined type `%s'",
+                            atype_str(type).c_str());
+                }
+            }
         }
 
         else if (itr.first == TokUserCheck)

--- a/test/attributes/CMakeLists.txt
+++ b/test/attributes/CMakeLists.txt
@@ -124,6 +124,9 @@ add_attributes_test(OUT_TYPE1 "unexpected pointer attributes for `int'" "")
 
 add_attributes_test(OUT_TYPE2 "`out' is invalid for plain type `mytype'" "")
 
+add_attributes_test(OUT_USER_TYPE_PTR
+                    "`out' is invalid for user defined type `MyStruct\\*'" "")
+
 # Checks for count/size
 add_attributes_test(
   COUNT_NO_DIR "size/count attributes must be used with pointer direction" "")

--- a/test/attributes/attributes.edl
+++ b/test/attributes/attributes.edl
@@ -3,6 +3,14 @@
 
 enclave
 {
+#ifdef OUT_USER_TYPE_PTR
+    struct MyStruct
+    {
+       size_t size;
+       [size=size] int* p;
+    };
+#endif
+
     untrusted
     {
 // Checks for string/wstring
@@ -104,6 +112,9 @@ enclave
 #endif
 #ifdef OUT_TYPE2
         void func([out] mytype x);
+#endif
+#ifdef OUT_USER_TYPE_PTR
+        void func([out] MyStruct* s);
 #endif
 
 // Checks for count/size

--- a/test/comprehensive/edl/deepcopy.edl
+++ b/test/comprehensive/edl/deepcopy.edl
@@ -129,13 +129,6 @@ enclave {
     // should take place.
     public void deepcopy_inout_count([in, out, count=1] CountStruct* s);
 
-    // Deep copy of one `CountStruct` with an embedded array out
-    // should take place.
-    public void deepcopy_out_count([out, count=1] CountStruct* s);
-
-    // Test for recursive copying for out structure.
-    public void deepcopy_nested_out([out, count=1] NestedStruct* n);
-
     // Test a real-world scenario.
     public void deepcopy_iovec([in, out, count=n] IOVEC* iov, size_t n);
   };

--- a/test/comprehensive/enc/testdeepcopy.cpp
+++ b/test/comprehensive/enc/testdeepcopy.cpp
@@ -235,25 +235,6 @@ void deepcopy_inout_count(CountStruct* s)
         s->ptr[i] = data[i];
 }
 
-void deepcopy_out_count(CountStruct* s)
-{
-    s->count = 7;
-    s->size = 64;
-    for (size_t i = 0; i < 3; ++i)
-        s->ptr[i] = data[i];
-}
-
-void deepcopy_nested_out(NestedStruct* n)
-{
-    OE_TEST(oe_is_within_enclave(n, sizeof(NestedStruct)));
-    OE_TEST(oe_is_within_enclave(n->array_of_int, 4 * sizeof(int)));
-    for (int i = 0; i < 4; ++i)
-        n->array_of_int[i] = i;
-    OE_TEST(oe_is_within_enclave(n->array_of_struct, 3 * sizeof(CountStruct)));
-    for (size_t i = 0; i < 3; ++i)
-        deepcopy_out_count(&(n->array_of_struct[i]));
-}
-
 void deepcopy_iovec(IOVEC* iov, size_t n)
 {
     OE_TEST(!(n && !iov));

--- a/test/comprehensive/host/testdeepcopy.cpp
+++ b/test/comprehensive/host/testdeepcopy.cpp
@@ -200,40 +200,6 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
     }
 
     {
-        CountStruct s{};
-        uint64_t p[3] = {0, 0, 0};
-        s.ptr = p;
-        OE_TEST(deepcopy_out_count(enclave, &s) == OE_OK);
-        OE_TEST(s.count == 7);
-        OE_TEST(s.size == 64);
-        test_struct(s, 3);
-    }
-
-    {
-        auto s = init_struct<CountStruct>();
-        int ints[]{0, 1, 2, 3};
-        ShallowStruct shallow{1, 8, nullptr};
-        CountStruct counts[]{s, s, s};
-        NestedStruct n{13, ints, &shallow, counts};
-        OE_TEST(deepcopy_nested_out(enclave, &n) == OE_OK);
-
-        for (size_t i = 0; i < 4; ++i)
-            OE_TEST(n.array_of_int[i] == static_cast<int>(i));
-
-        // Out-only deepcopy does not support shallow pointer passing.
-        OE_TEST(n.shallow_struct != &shallow);
-        OE_TEST(n.array_of_struct == counts);
-
-        for (size_t i = 0; i < 3; ++i)
-            for (size_t j = 0; j < 8; ++j)
-            {
-                OE_TEST(n.array_of_struct[i].count == 7);
-                OE_TEST(n.array_of_struct[i].size == 64);
-                OE_TEST(n.array_of_struct[i].ptr[j] == data[j]);
-            }
-    }
-
-    {
         IOVEC iov[2];
         char buf0[8] = "red";
 

--- a/utils.h
+++ b/utils.h
@@ -293,7 +293,9 @@ void iterate_deep_copyable_fields(UserType* user_type, Action&& action)
     }
 }
 
-inline UserType* get_user_type_for_deep_copy(Edl* edl, Decl* d)
+inline UserType* get_user_type_for_deep_copy(
+    const std::vector<UserType*>& types,
+    Decl* d)
 {
     Type* t = d->type_;
     UserType* ut = nullptr;
@@ -308,7 +310,7 @@ inline UserType* get_user_type_for_deep_copy(Edl* edl, Decl* d)
     // EDL types can masquerade as foregin types. Depends on what
     // the parser wants to do.
     if (t->tag_ == Foreign || t->tag_ == Struct)
-        ut = get_user_type(edl, t->name_);
+        ut = get_user_type(types, t->name_);
     if (!ut)
         return nullptr;
 
@@ -317,6 +319,11 @@ inline UserType* get_user_type_for_deep_copy(Edl* edl, Decl* d)
         ut, [&deep_copyable](Decl*) { deep_copyable = true; });
 
     return deep_copyable ? ut : nullptr;
+}
+
+inline UserType* get_user_type_for_deep_copy(Edl* edl, Decl* d)
+{
+    return get_user_type_for_deep_copy(edl->types_, d);
 }
 
 inline const char* path_sep()


### PR DESCRIPTION
This PR disables the support of deepcopy on out parameters (i.e., annotate a pointer of user-defined struct with out attribute). This is because of the callee cannot know the size (i.e., a member of the struct whose value will be copied) of nested buffers.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>