### PR TITLE
Prevent struct members used by size/count attributes from being modified by the callee during deep copy

### DIFF
--- a/ast.h
+++ b/ast.h
@@ -57,6 +57,7 @@ struct Attrs
     bool string_;
     bool wstring_;
     bool user_check_;
+    bool is_size_or_count_;
     Token size_;
     Token count_;
 };

--- a/parser.h
+++ b/parser.h
@@ -92,7 +92,6 @@ class Parser
     void error_size_count(Function* f);
     void check_size_count_decls(
         const std::string& parent_name,
-        bool is_function,
         const std::vector<Decl*>& decls);
 
     AttrTok check_attribute(Token t);

--- a/test/attributes/CMakeLists.txt
+++ b/test/attributes/CMakeLists.txt
@@ -212,7 +212,13 @@ add_attributes_test(STRUCT_COUNT_INVALID_PROP1
 
 add_attributes_test(STRUCT_COUNT_INVALID_PROP2 "size/count has invalid type" "")
 
+add_attributes_test(STRUCT_COUNT_INVALID_PROP3
+                    "could not find declaration for 'p_count'" "")
+
 add_attributes_test(STRUCT_SIZE_INVALID_PROP1
                     "could not find declaration for 'p_size'" "")
 
 add_attributes_test(STRUCT_SIZE_INVALID_PROP2 "size/count has invalid type" "")
+
+add_attributes_test(STRUCT_SIZE_INVALID_PROP3
+                    "could not find declaration for 'p_size'" "")

--- a/test/attributes/attributes.edl
+++ b/test/attributes/attributes.edl
@@ -246,6 +246,13 @@ enclave
        int* p_count;
     };
 #endif
+#ifdef STRUCT_COUNT_INVALID_PROP3
+    struct MyStruct
+    {
+       size_t p_size;
+       [size=p_size, count=p_count] int* p;
+    };
+#endif
 #ifdef STRUCT_SIZE_INVALID_PROP1
     struct MyStruct
     {
@@ -257,6 +264,13 @@ enclave
     {
        [size=p_size] int* p;
        int* p_size;
+    };
+#endif
+#ifdef STRUCT_SIZE_INVALID_PROP3
+    struct MyStruct
+    {
+       size_t p_count;
+       [size=p_size, count=p_count] int* p;
     };
 #endif
 

--- a/test/comprehensive/edl/deepcopy.edl
+++ b/test/comprehensive/edl/deepcopy.edl
@@ -131,5 +131,50 @@ enclave {
 
     // Test a real-world scenario.
     public void deepcopy_iovec([in, out, count=n] IOVEC* iov, size_t n);
+
+    // Expect the callee to set a large count value on return.
+    public void deepcopy_countparam_return_large([in, out, count=1] CountParamStruct* s);
+
+    // Expect the callee to set a large size value on return.
+    public void deepcopy_sizeparam_return_large([in, out, count=1] SizeParamStruct* s);
+
+    // Expect the callee to set a large size and count value on return.
+    public void deepcopy_countsizeparam_return_large([in, out, count=1] CountSizeParamStruct* s);
+
+    // Expect the callee to set a large size and count value on return.
+    public void deepcopy_countsize_return_large([in, out, count=1] CountSizeStruct* s);
+
+    public void test_deepcopy_ocalls();
+  };
+
+  untrusted
+  {
+    // Deep copy of one `CountParamStruct` with an embedded array
+    // should take place.
+    void ocall_deepcopy_countparam([in, out, count=1] CountParamStruct* s);
+
+    // Deep copy of one `SizeParamStruct` with an embedded array
+    // should take place.
+    void ocall_deepcopy_sizeparam([in, out, count=1] SizeParamStruct* s);
+
+    // Deep copy of two `CountSizeParamStruct`s each with an embedded
+    // array and different counts should take place.
+    void ocall_deepcopy_countsizeparam([in, out, count=1] CountSizeParamStruct* s);
+
+    // Deep copy of one `CountSizeStruct` each with an embedded
+    // array should take place.
+    void ocall_deepcopy_countsize([in, out, count=1] CountSizeStruct* s);
+
+    // Expect the callee to set a large count value on return.
+    void ocall_deepcopy_countparam_return_large([in, out, count=1] CountParamStruct* s);
+
+    // Expect the callee to set a large count value on return.
+    void ocall_deepcopy_sizeparam_return_large([in, out, count=1] SizeParamStruct* s);
+
+    // Expect the callee to set a large count value on return.
+    void ocall_deepcopy_countsizeparam_return_large([in, out, count=1] CountSizeParamStruct* s);
+
+    // Expect the callee to set a large count value on return.
+    void ocall_deepcopy_countsize_return_large([in, out, count=1] CountSizeStruct* s);
   };
 };

--- a/utils.h
+++ b/utils.h
@@ -288,7 +288,12 @@ void iterate_deep_copyable_fields(UserType* user_type, Action&& action)
 
     for (Decl* prop : user_type->fields_)
     {
-        if (prop->attrs_)
+        /*
+         * The member is deep copyable only if it has attrs_ and the
+         * attrs->is_size_or_count_ is false (i.e., the member is not used by
+         * size/count attribute).
+         */
+        if (prop->attrs_ && !prop->attrs_->is_size_or_count_)
             action(prop);
     }
 }


### PR DESCRIPTION
This PR fixes a security issue that callee can set arbitrary value to the struct member used by size/count during the deepcopy. More specifically, now the generated code will not copy the struct member set by the callee to the caller if the member is used by size/count attributes.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>