### PR TITLE
Update oeedger8r

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,16 @@ if (NOT ";Debug;RelWithDebInfo;Release;" MATCHES ";${CMAKE_BUILD_TYPE};")
     FATAL_ERROR "CMAKE_BUILD_TYPE must be Debug, RelWithDebInfo or Release")
 endif ()
 
+# Set compiler search order to prefer Clang
+# This has to be done before `project`
+# http://cmake.3232098.n2.nabble.com/Prefer-clang-over-gcc-td7597742.html
+if (UNIX)
+  set(CMAKE_C_COMPILER_NAMES clang-8 clang-7 clang cc)
+  set(CMAKE_CXX_COMPILER_NAMES clang++-8 clang++-7 clang c++)
+else ()
+  # Prefer platform's default compiler.
+endif ()
+
 project(oeedger8r)
 
 # Collect Git info

--- a/test/virtual/enclave_impl.h
+++ b/test/virtual/enclave_impl.h
@@ -4,6 +4,7 @@
 #include <openenclave/bits/result.h>
 #include <openenclave/bits/types.h>
 
+#include <cstdlib>
 #include <map>
 
 #define OE_ECALL_ID_NULL OE_UINT64_MAX


### PR DESCRIPTION
- Fix missing include that results in compiler error with newer libcxx in Ubuntu 20.04
- Prefer clang-8

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>