### PR TITLE
Update the generated variable names to conform OE guidelines

### DIFF
--- a/src/c_emitter.h
+++ b/src/c_emitter.h
@@ -125,9 +125,9 @@ class CEmitter
               << "               flags,"
               << "               settings,"
               << "               setting_count,"
-              << "               __" + edl_->name_ + "_ocall_function_table,"
+              << "               _" + edl_->name_ + "_ocall_function_table,"
               << "               " + to_str(edl_->untrusted_funcs_.size()) + ","
-              << "               __" + edl_->name_ + "_ecall_info_table,"
+              << "               _" + edl_->name_ + "_ecall_info_table,"
               << "                " + to_str(edl_->trusted_funcs_.size()) + ","
               << "               enclave);"
               << "}"
@@ -151,7 +151,7 @@ class CEmitter
 
     void trusted_function_names()
     {
-        out() << "static const oe_ecall_info_t __" + edl_->name_ +
+        out() << "static const oe_ecall_info_t _" + edl_->name_ +
                      "_ecall_info_table[] = "
               << "{";
         for (Function* f : edl_->trusted_funcs_)
@@ -191,12 +191,12 @@ class CEmitter
         (void)ocall;
         out() << "typedef struct _" + f->name_ + "_args_t"
               << "{"
-              << "    oe_result_t _result;"
+              << "    oe_result_t result;"
               << "    uint8_t* deepcopy_out_buffer;"
               << "    size_t deepcopy_out_buffer_size;";
         indent_ = "    ";
         if (f->rtype_->tag_ != Void)
-            out() << atype_str(f->rtype_) + " _retval;";
+            out() << atype_str(f->rtype_) + " retval;";
         for (Decl* p : f->params_)
         {
             out() << mdecl_str(p->name_, p->type_, p->dims_, p->attrs_) + ";";
@@ -204,7 +204,7 @@ class CEmitter
                 out() << "size_t " + p->name_ + "_len;";
         }
         if (f->errno_)
-            out() << "int _ocall_errno;";
+            out() << "int ocall_errno;";
         indent_ = "";
         out() << "} " + f->name_ + "_args_t;"
               << "";
@@ -212,21 +212,21 @@ class CEmitter
 
     void ecalls_table()
     {
-        out() << "oe_ecall_func_t __oe_ecalls_table[] = {";
+        out() << "oe_ecall_func_t oe_ecalls_table[] = {";
         size_t idx = 0;
         for (Function* f : edl_->trusted_funcs_)
             out() << "    (oe_ecall_func_t) ecall_" + f->name_ +
                          (++idx < edl_->trusted_funcs_.size() ? "," : "");
         out() << "};"
               << ""
-              << "size_t __oe_ecalls_table_size = "
-                 "OE_COUNTOF(__oe_ecalls_table);"
+              << "size_t oe_ecalls_table_size = "
+                 "OE_COUNTOF(oe_ecalls_table);"
               << "";
     }
 
     void ocalls_table()
     {
-        out() << "static oe_ocall_func_t __" + edl_->name_ +
+        out() << "static oe_ocall_func_t _" + edl_->name_ +
                      "_ocall_function_table[] = {";
         for (Function* f : edl_->untrusted_funcs_)
             out() << "    (oe_ocall_func_t) ocall_" + f->name_ + ",";

--- a/src/w_emitter.h
+++ b/src/w_emitter.h
@@ -161,7 +161,7 @@ class WEmitter
         {
             out() << "             enclave,"
                   << "             &global_id,"
-                  << "             __" + edl_->name_ + "_ecall_info_table[" +
+                  << "             _" + edl_->name_ + "_ecall_info_table[" +
                          fcn_id + "].name,";
         }
         else
@@ -181,7 +181,7 @@ class WEmitter
             << "    OE_ADD_SIZE(_output_buffer_offset, 1, sizeof(*_pargs_out));"
             << "    "
             << "    /* Check if the call succeeded. */"
-            << "    if ((_result = _pargs_out->_result) != OE_OK)"
+            << "    if ((_result = _pargs_out->result) != OE_OK)"
             << "        goto done;"
             << ""
             << "    /* Currently exactly _output_buffer_size bytes must be "
@@ -194,7 +194,7 @@ class WEmitter
             << ""
             << "    /* Unmarshal return value and out, in-out parameters. */";
         if (f->rtype_->tag_ != Void)
-            out() << "    *_retval = _pargs_out->_retval;";
+            out() << "    *_retval = _pargs_out->retval;";
         else
             out() << "    /* No return value. */";
         out() << "";
@@ -720,7 +720,7 @@ class WEmitter
             return;
         out() << "    /* Retrieve propagated errno from OCALL. */";
         if (f->errno_)
-            out() << "    oe_errno = _pargs_out->_ocall_errno;"
+            out() << "    oe_errno = _pargs_out->ocall_errno;"
                   << "";
         else
             out() << "    /* Errno propagation not enabled. */";

--- a/test/comprehensive/edltestutils.h
+++ b/test/comprehensive/edltestutils.h
@@ -15,12 +15,12 @@ void check_type(Args&...)
 {
 }
 
-// Check the type of _retval field of a given args type.
+// Check the type of retval field of a given args type.
 template <typename args_type, typename R>
 void check_return_type()
 {
     args_type args;
-    check_type<R>(args._retval);
+    check_type<R>(args.retval);
 }
 
 template <std::size_t N>

--- a/test/comprehensive/enc/testerrno.cpp
+++ b/test/comprehensive/enc/testerrno.cpp
@@ -41,14 +41,14 @@ void test_errno_edl_ocalls()
     OE_TEST(errno == 0x1111);
 
     // Mashalling structs for ocalls marked with propagate_errno should have an
-    // int _ocall_errno field. If not the case, the following code will not
+    // int ocall_errno field. If not the case, the following code will not
     // compile.
     {
         ocall_errno_args_t args1;
-        check_type<int>(args1._ocall_errno);
+        check_type<int>(args1.ocall_errno);
 
         ocall_noop_args_t args2;
-        check_type<int>(args2._ocall_errno);
+        check_type<int>(args2.ocall_errno);
     }
 
     // Marshalling structs without the propagate_errno annotation will not have

--- a/test/comprehensive/host/teststring.cpp
+++ b/test/comprehensive/host/teststring.cpp
@@ -85,7 +85,7 @@ oe_result_t ecall_string_no_null_terminator_modified(
     if ((_result = oe_call_enclave_function(
              enclave,
              &global_id,
-             __all_ecall_info_table[all_fcn_id_ecall_string_no_null_terminator]
+             _all_ecall_info_table[all_fcn_id_ecall_string_no_null_terminator]
                  .name,
              _input_buffer,
              _input_buffer_size,
@@ -99,7 +99,7 @@ oe_result_t ecall_string_no_null_terminator_modified(
     OE_ADD_SIZE(_output_buffer_offset, 1, sizeof(*_pargs_out));
 
     /* Check if the call succeeded */
-    if ((_result = _pargs_out->_result) != OE_OK)
+    if ((_result = _pargs_out->result) != OE_OK)
         goto done;
 
     /* Currently exactly _output_buffer_size bytes must be written */
@@ -197,7 +197,7 @@ oe_result_t ecall_wstring_no_null_terminator_modified(
     if ((_result = oe_call_enclave_function(
              enclave,
              &global_id,
-             __all_ecall_info_table[all_fcn_id_ecall_wstring_no_null_terminator]
+             _all_ecall_info_table[all_fcn_id_ecall_wstring_no_null_terminator]
                  .name,
              _input_buffer,
              _input_buffer_size,
@@ -211,7 +211,7 @@ oe_result_t ecall_wstring_no_null_terminator_modified(
     OE_ADD_SIZE(_output_buffer_offset, 1, sizeof(*_pargs_out));
 
     /* Check if the call succeeded */
-    if ((_result = _pargs_out->_result) != OE_OK)
+    if ((_result = _pargs_out->result) != OE_OK)
         goto done;
 
     /* Currently exactly _output_buffer_size bytes must be written */

--- a/test/virtual/enclave.cpp
+++ b/test/virtual/enclave.cpp
@@ -10,15 +10,15 @@ extern "C"
 {
     oe_enclave_t* _enclave;
 
-    extern "C" oe_ecall_func_t __oe_ecalls_table[];
-    extern "C" size_t __oe_ecalls_table_size;
+    extern "C" oe_ecall_func_t oe_ecalls_table[];
+    extern "C" size_t oe_ecalls_table_size;
 
     OE_EXPORT
     void set_enclave_object(oe_enclave_t* enclave)
     {
         _enclave = enclave;
-        _enclave->_ecall_table = __oe_ecalls_table;
-        _enclave->_num_ecalls = static_cast<uint32_t>(__oe_ecalls_table_size);
+        _enclave->_ecall_table = oe_ecalls_table;
+        _enclave->_num_ecalls = static_cast<uint32_t>(oe_ecalls_table_size);
     }
 
     bool oe_is_within_enclave(const void* ptr, uint64_t size)

--- a/test/virtual/include/openenclave/edger8r/common.h
+++ b/test/virtual/include/openenclave/edger8r/common.h
@@ -103,18 +103,18 @@ done:
  * Compute and set the pointer value for the given parameter within the input
  * buffer. Make sure that the buffer has enough space.
  */
-#define OE_SET_IN_POINTER(argname, argcount, argsize, argtype)             \
-    if (pargs_in->argname)                                                 \
-    {                                                                      \
-        size_t _size;                                                      \
-        OE_COMPUTE_SIZE(argcount, argsize, _size);                         \
-        pargs_in->argname = (argtype)(input_buffer + input_buffer_offset); \
-        OE_ADD_SIZE(input_buffer_offset, 1, _size);                        \
-        if (input_buffer_offset > input_buffer_size)                       \
-        {                                                                  \
-            _result = OE_BUFFER_TOO_SMALL;                                 \
-            goto done;                                                     \
-        }                                                                  \
+#define OE_SET_IN_POINTER(argname, argcount, argsize, argtype)               \
+    if (_pargs_in->argname)                                                  \
+    {                                                                        \
+        size_t _size;                                                        \
+        OE_COMPUTE_SIZE(argcount, argsize, _size);                           \
+        _pargs_in->argname = (argtype)(input_buffer + _input_buffer_offset); \
+        OE_ADD_SIZE(_input_buffer_offset, 1, _size);                         \
+        if (_input_buffer_offset > input_buffer_size)                        \
+        {                                                                    \
+            _result = OE_BUFFER_TOO_SMALL;                                   \
+            goto done;                                                       \
+        }                                                                    \
     }
 
 #define OE_SET_IN_OUT_POINTER OE_SET_IN_POINTER
@@ -123,18 +123,18 @@ done:
  * Compute and set the pointer value for the given parameter within the output
  * buffer. Make sure that the buffer has enough space.
  */
-#define OE_SET_OUT_POINTER(argname, argcount, argsize, argtype)              \
-    do                                                                       \
-    {                                                                        \
-        size_t _size;                                                        \
-        OE_COMPUTE_SIZE(argcount, argsize, _size);                           \
-        pargs_in->argname = (argtype)(output_buffer + output_buffer_offset); \
-        OE_ADD_SIZE(output_buffer_offset, 1, _size);                         \
-        if (output_buffer_offset > output_buffer_size)                       \
-        {                                                                    \
-            _result = OE_BUFFER_TOO_SMALL;                                   \
-            goto done;                                                       \
-        }                                                                    \
+#define OE_SET_OUT_POINTER(argname, argcount, argsize, argtype)                \
+    do                                                                         \
+    {                                                                          \
+        size_t _size;                                                          \
+        OE_COMPUTE_SIZE(argcount, argsize, _size);                             \
+        _pargs_in->argname = (argtype)(output_buffer + _output_buffer_offset); \
+        OE_ADD_SIZE(_output_buffer_offset, 1, _size);                          \
+        if (_output_buffer_offset > output_buffer_size)                        \
+        {                                                                      \
+            _result = OE_BUFFER_TOO_SMALL;                                     \
+            goto done;                                                         \
+        }                                                                      \
     } while (0)
 
 /**
@@ -143,20 +143,20 @@ done:
  * Also copy the contents of the corresponding in-out pointer in the input
  * buffer.
  */
-#define OE_COPY_AND_SET_IN_OUT_POINTER(argname, argcount, argsize, argtype)  \
-    if (pargs_in->argname)                                                   \
-    {                                                                        \
-        size_t _size;                                                        \
-        OE_COMPUTE_SIZE(argcount, argsize, _size);                           \
-        argtype _p_in = (argtype)pargs_in->argname;                          \
-        pargs_in->argname = (argtype)(output_buffer + output_buffer_offset); \
-        OE_ADD_SIZE(output_buffer_offset, 1, _size);                         \
-        if (output_buffer_offset > output_buffer_size)                       \
-        {                                                                    \
-            _result = OE_BUFFER_TOO_SMALL;                                   \
-            goto done;                                                       \
-        }                                                                    \
-        memcpy(pargs_in->argname, _p_in, _size);                             \
+#define OE_COPY_AND_SET_IN_OUT_POINTER(argname, argcount, argsize, argtype)    \
+    if (_pargs_in->argname)                                                    \
+    {                                                                          \
+        size_t _size;                                                          \
+        OE_COMPUTE_SIZE(argcount, argsize, _size);                             \
+        argtype _p_in = (argtype)_pargs_in->argname;                           \
+        _pargs_in->argname = (argtype)(output_buffer + _output_buffer_offset); \
+        OE_ADD_SIZE(_output_buffer_offset, 1, _size);                          \
+        if (_output_buffer_offset > output_buffer_size)                        \
+        {                                                                      \
+            _result = OE_BUFFER_TOO_SMALL;                                     \
+            goto done;                                                         \
+        }                                                                      \
+        memcpy(_pargs_in->argname, _p_in, _size);                              \
     }
 
 /**


### PR DESCRIPTION
This PR updates generated variable names to conform the developer guidelines of OE. The detail includes
- No longer use double underscores
  - __oe_ecalls_table -> oe_ecalls_table (which will be referenced by the OE runtime)
  - __foo_ocall_function_table -> _foo_ocall_function_table  (only used in the local file)
- Add underscore to the local variables
- Remove underscore from the struct members

Refer to https://github.com/openenclave/openenclave/issues/3210 for more detail.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>