### PR TITLE
Add warning options for non-serializable cases

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -13,6 +14,7 @@
 #include "lexer.h"
 #include "parser.h"
 #include "preprocessor.h"
+#include "warnings.h"
 
 class Parser
 {
@@ -23,6 +25,7 @@ class Parser
     std::string basename_;
     std::vector<std::string> searchpaths_;
     std::vector<std::string> defines_;
+    std::unordered_map<Warning, WarningState, WarningHash> warnings_;
 
     Lexer* lex_;
     Token t_;
@@ -90,6 +93,16 @@ class Parser
     void append_function(std::vector<Function*>& funcs, Function* f);
     void warn_allow_list(const std::string& fname);
     void warn_non_portable(Function* f);
+    void warn_function_return_ptr(const std::string& fname, Type* t);
+    void warn_ptr_in_local_struct(const std::string& sname, Decl* d);
+    void check_function_param(const std::string& fname, Decl* d);
+    void warn_foreign_ptr(
+        const std::string& fname,
+        const std::string& type,
+        const std::string& param);
+    void warn_ptr_in_function(
+        const std::string& fname,
+        const std::string& param);
     void error_size_count(Function* f);
     void check_size_count_decls(
         const std::string& parent_name,
@@ -108,6 +121,7 @@ class Parser
         const std::string& filename,
         const std::vector<std::string>& searchpaths,
         const std::vector<std::string>& defines,
+        const std::unordered_map<Warning, WarningState, WarningHash>& warnings,
         bool experimental);
     ~Parser();
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -211,6 +211,15 @@ inline std::string btype(Type* t)
     return atype_str(t);
 }
 
+inline bool has_size_or_count_attr(Decl* d)
+{
+    if (!d->attrs_)
+        return false;
+    if (d->attrs_->count_.is_empty() && d->attrs_->size_.is_empty())
+        return false;
+    return true;
+}
+
 inline std::string count_attr_str(
     const Token& t,
     const std::string& prefix = "")

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -1,0 +1,40 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef WARNINGS_H
+#define WARNINGS_H
+
+enum class Warning
+{
+    All,
+    Error,
+    ForeignTypePtr,
+    PtrInStruct,
+    PtrInFunction,
+    ReturnPtr,
+    Unknown
+};
+
+/* A bug with C++11 prevents an enum class directly be used as a key in
+ * an unordered_map. As a workaround, we have to provide a customized hash
+ * function as a third argument to the unordered_map. Note that the bug
+ * was fixed in C++14.
+ * See http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#2148.
+ */
+struct WarningHash
+{
+    std::size_t operator()(Warning w) const
+    {
+        return static_cast<std::size_t>(w);
+    }
+};
+
+enum class WarningState
+{
+    Ignore,
+    Warning,
+    Error,
+    Unknown
+};
+
+#endif // WARNINGS_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(import)
 add_subdirectory(prefix)
 add_subdirectory(preprocessor)
 add_subdirectory(safe_math)
+add_subdirectory(warnings)
 
 # Virtual Mode execution for tests.
 add_subdirectory(virtual)

--- a/test/warnings/CMakeLists.txt
+++ b/test/warnings/CMakeLists.txt
@@ -1,0 +1,294 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+function (add_warnings_test test_name options pass_re fail_re)
+  add_test(
+    NAME oeedger8r_${test_name}
+    COMMAND oeedger8r --header-only --search-path ${CMAKE_CURRENT_SOURCE_DIR}
+            -D${test_name} ${options} warnings.edl)
+  if (${fail_re})
+    set_tests_properties(
+      oeedger8r_${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "${pass_re}"
+                                        FAIL_REGULAR_EXPRESSION "${fail_re}")
+  else ()
+    set_tests_properties(oeedger8r_${test_name}
+                         PROPERTIES PASS_REGULAR_EXPRESSION "${pass_re}")
+  endif ()
+endfunction ()
+
+function (add_werror_test test_name options pass_re fail_re)
+  add_test(NAME oeedger8r_${test_name}
+           COMMAND oeedger8r --header-only --search-path
+                   ${CMAKE_CURRENT_SOURCE_DIR} ${options} werror.edl)
+  if (${fail_re})
+    set_tests_properties(
+      oeedger8r_${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "${pass_re}"
+                                        FAIL_REGULAR_EXPRESSION "${fail_re}")
+  else ()
+    set_tests_properties(oeedger8r_${test_name}
+                         PROPERTIES PASS_REGULAR_EXPRESSION "${pass_re}")
+  endif ()
+endfunction ()
+
+add_warnings_test(
+  PTR_IN_STRUCT
+  "-Wptr-in-struct"
+  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "")
+
+add_warnings_test(
+  NO_PTR_IN_STRUCT
+  "-Wptr-in-struct"
+  ""
+  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+)
+
+add_warnings_test(
+  WALL_PTR_IN_STRUCT
+  "-Wall"
+  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "")
+
+add_warnings_test(
+  WALL_NO_PTR_IN_STRUCT
+  "-Wall;-Wno-ptr-in-struct"
+  ""
+  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+)
+
+add_warnings_test(
+  RETURN_PTR_TYPE1
+  "-Wreturn-ptr"
+  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "")
+
+add_warnings_test(
+  RETURN_PTR_TYPE2
+  "-Wreturn-ptr"
+  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "")
+
+add_warnings_test(
+  RETURN_PTR_TYPE3
+  "-Wreturn-ptr"
+  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "")
+
+add_warnings_test(
+  WALL_RETURN_PTR
+  "-Wall"
+  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "")
+
+add_warnings_test(
+  WALL_NO_RETURN_PTR
+  "-Wall;-Wno-return-ptr"
+  ""
+  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+)
+
+add_warnings_test(
+  PTR_IN_FUNCTION_TYPE1
+  "-Wptr-in-function"
+  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "")
+
+add_warnings_test(
+  PTR_IN_FUNCTION_TYPE2
+  "-Wptr-in-function"
+  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "")
+
+add_warnings_test(
+  PTR_IN_FUNCTION_TYPE3
+  "-Wptr-in-function"
+  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "")
+
+add_warnings_test(
+  PTR_IN_FUNCTION_TYPE4
+  "-Wptr-in-function"
+  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "")
+
+add_warnings_test(
+  WALL_PTR_IN_FUNCTION
+  "-Wall"
+  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "")
+
+add_warnings_test(
+  WALL_NO_PTR_IN_FUNCTION
+  "-Wall;-Wno-ptr-in-function"
+  ""
+  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+)
+
+add_warnings_test(
+  FOREIGN_TYPE_PTR_TYPE1
+  "-Wforeign-type-ptr"
+  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "")
+
+add_warnings_test(
+  FOREIGN_TYPE_PTR_TYPE2
+  "-Wforeign-type-ptr"
+  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "")
+
+add_warnings_test(
+  FOREIGN_TYPE_PTR_TYPE3
+  "-Wforeign-type-ptr"
+  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "")
+
+add_warnings_test(
+  WALL_FOREIGN_TYPE_PTR
+  "-Wall"
+  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "")
+
+add_warnings_test(
+  WALL_NO_FOREIGN_TYPE_PTR
+  "-Wall;-Wno-foreign-type-ptr"
+  ""
+  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+)
+
+add_warnings_test(
+  NON_FOREIGN_TYPE_PTR_TYPE1
+  "-Wforeign-type-ptr"
+  ""
+  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+)
+
+add_warnings_test(
+  NON_FOREIGN_TYPE_PTR_TYPE2
+  "-Wforeign-type-ptr"
+  ""
+  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+)
+
+add_werror_test(
+  WERROR_RETURN_PTR
+  "-Werror;-Wreturn-ptr"
+  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "")
+
+add_werror_test(
+  WERROR_EQUAL_TO_RETURN_PTR_TYPE1
+  "-Werror=return-ptr"
+  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "")
+
+add_werror_test(
+  WERROR_EQUAL_TO_RETURN_PTR_TYPE2
+  "-Wreturn-ptr;-Werror=return-ptr"
+  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "")
+
+add_werror_test(
+  WERROR_NO_RETURN_PTR_TYPE1
+  "-Werror;-Wreturn-ptr;-Wno-return-ptr"
+  ""
+  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+)
+
+add_werror_test(
+  WERROR_NO_RETURN_PTR_TYPE2
+  "-Werror=return-ptr;-Wno-return-ptr"
+  ""
+  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+)
+
+add_werror_test(
+  WERROR_NO_RETURN_PTR_TYPE3
+  "-Wreturn-ptr;-Werror=return-ptr;-Wno-return-ptr"
+  ""
+  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+)
+
+add_werror_test(
+  NO_WERROR_RETURN_PTR
+  "-Werror;-Wreturn-ptr;-Wno-error"
+  "warning: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+)
+
+add_werror_test(
+  WERROR_PTR_IN_STRUCT
+  "-Werror;-Wptr-in-struct"
+  "error: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "")
+
+add_werror_test(
+  WERROR_EQUAL_TO_PTR_IN_STRUCT
+  "-Werror=ptr-in-struct"
+  "error: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "")
+
+add_werror_test(
+  WERROR_NO_PTR_IN_STRUCT
+  "-Werror;-Wptr-in-struct;-Wno-ptr-in-struct"
+  ""
+  "error: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+)
+
+add_werror_test(
+  NO_WERROR_PTR_IN_STRUCT
+  "-Werror;-Wptr-in-struct;-Wno-error"
+  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "error: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+)
+
+add_werror_test(
+  WERROR_PTR_IN_FUNCTION
+  "-Werror;-Wptr-in-function"
+  "error: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "")
+
+add_werror_test(
+  WERROR_EQUAL_TO_PTR_IN_FUNCTION
+  "-Werror=ptr-in-function"
+  "error: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "")
+
+add_werror_test(
+  WERROR_NO_PTR_IN_FUNCTION
+  "-Werror;-Wptr-in-function;-Wno-ptr-in-function"
+  ""
+  "error: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+)
+
+add_werror_test(
+  NO_WERROR_PTR_IN_FUNCTION
+  "-Werror;-Wptr-in-function;-Wno-error"
+  "warning: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "error: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+)
+
+add_werror_test(
+  WERROR_FOREIGN_TYPE_PTR
+  "-Werror;-Wforeign-type-ptr"
+  "error: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "")
+
+add_werror_test(
+  WERROR_EQUAL_TO_FOREIGN_TYPE_PTR
+  "-Werror=foreign-type-ptr"
+  "error: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "")
+
+add_werror_test(
+  WERROR_NO_FOREIGN_TYPE_PTR
+  "-Werror;-Wforeign-type-ptr;-Wno-foreign-type-ptr"
+  ""
+  "error: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+)
+
+add_werror_test(
+  NO_WERROR_FOREIGN_TYPE_PTR
+  "-Werror;-Wforeign-type-ptr;-Wno-error"
+  "warning: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "error: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+)

--- a/test/warnings/warnings.edl
+++ b/test/warnings/warnings.edl
@@ -1,0 +1,114 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave
+{
+#ifdef PTR_IN_STRUCT
+    struct MyStruct
+    {
+       size_t size;
+       int* p;
+    };
+#endif
+#ifdef NO_POINTER_IN_STRUCT
+    struct MyStruct
+    {
+       size_t size;
+       [size = size] int* p;
+    };
+#endif
+#ifdef WALL_PTR_IN_STRUCT
+    struct MyStruct
+    {
+       size_t size;
+       int* p;
+    };
+#endif
+#ifdef WALL_NO_PTR_IN_STRUCT
+    struct MyStruct
+    {
+       size_t size;
+       int* p;
+    };
+#endif
+#ifdef NON_FOREIGN_TYPE_PTR_TYPE1
+    struct MyStruct
+    {
+       size_t size;
+       [size=size] int* p;
+    };
+#endif
+#ifdef NON_FOREIGN_TYPE_PTR_TYPE2
+    struct MyStruct
+    {
+       size_t size;
+       int* p;
+    };
+#endif
+
+    struct TestStruct
+    {
+       size_t size;
+       [size = size] int* p;
+    };
+
+    untrusted
+    {
+#ifdef RETURN_PTR_TYPE1
+        MyStruct* func();
+#endif
+#ifdef RETURN_PTR_TYPE2
+        void* func();
+#endif
+#ifdef RETURN_PTR_TYPE3
+        const int* func();
+#endif
+#ifdef WALL_RETURN_PTR
+        MyStruct* func();
+#endif
+#ifdef WALL_NO_RETURN_PTR
+        MyStruct* func();
+#endif
+
+#ifdef PTR_IN_FUNCTION_TYPE1
+        void func(TestStruct* s);
+#endif
+#ifdef PTR_IN_FUNCTION_TYPE2
+        void func(struct TestStruct* s);
+#endif
+#ifdef PTR_IN_FUNCTION_TYPE3
+        void func(const TestStruct* s);
+#endif
+#ifdef PTR_IN_FUNCTION_TYPE4
+        void func(int* s);
+#endif
+#ifdef WALL_PTR_IN_FUNCTION
+        void func(TestStruct* s);
+#endif
+#ifdef WALL_PTR_NO_IN_FUNCTION
+        void func(TestStruct* s);
+#endif
+
+#ifdef FOREIGN_TYPE_PTR_TYPE1
+        void func(MyStruct* s);
+#endif
+#ifdef FOREIGN_TYPE_PTR_TYPE2
+        void func(struct MyStruct* s);
+#endif
+#ifdef FOREIGN_TYPE_PTR_TYPE3
+        void func(const MyStruct* s);
+#endif
+#ifdef WALL_FOREIGN_TYPE_PTR
+        void func(MyStruct* s);
+#endif
+#ifdef WALL_NO_FOREIGN_TYPE_PTR
+        void func(MyStruct* s);
+#endif
+#ifdef NON_FOREIGN_TYPE_PTR_TYPE1
+        void func(MyStruct* s);
+#endif
+#ifdef NON_FOREIGN_TYPE_PTR_TYPE2
+        void func(MyStruct* s);
+#endif
+    };
+};

--- a/test/warnings/werror.edl
+++ b/test/warnings/werror.edl
@@ -1,0 +1,20 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+enclave
+{
+    struct MyStruct
+    {
+       size_t size;
+       int* p;
+    };
+
+    untrusted
+    {
+        Mystruct* foo();
+
+        void bar(TestStruct* s);
+
+        void abc(int* s);
+    };
+};


### PR DESCRIPTION
This PR is based on the [Enforcing full serialization in EDL proposal](https://github.com/openenclave/openenclave/blob/master/docs/DesignDocs/full_edl_serialization.md). More specifically, adding the following command line options:
- `-Wreturn-ptr`: Check if an ocall or ecall returns a pointer
- `-Wptr-in-struct`: Check if a user-defined struct includes a un-annotated pointer
- `-Wforeign-type-ptr`: Check if an ocall or ecall includes a parameter that is a pointer of a foreign type
- `-Wptr-in-function`: Check if an ocall or ecall includes a un-annotated pointer argument
- `-Wall`: Enable all the warning options
- `-Wno-<option>`: Disable the corresponding warning
- `-Werror`: Turn warnings into errors
- `-Werror=<option>`: Turn the specified warning into an error

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>