### PR TITLE
Fix the check of foreign ptr warning

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1013,12 +1013,13 @@ void Parser::check_function_param(const std::string& fname, Decl* d)
     if (type->tag_ == Const)
         type = type->t_;
 
-    /* Check if we have the local definition of the type. */
+    /*
+     * Warn if we do not have the local definition of the type.
+     * Note that a foreign type can also be a struct.
+     */
     UserType* ut = get_user_type(types_, type->name_);
-    if (ut)
-        return;
-
-    warn_foreign_ptr(fname, type->name_, d->name_);
+    if ((type->tag_ == Foreign || type->tag_ == Struct) && !ut)
+        warn_foreign_ptr(fname, type->name_, d->name_);
 }
 
 void Parser::warn_ptr_in_function(

--- a/test/warnings/CMakeLists.txt
+++ b/test/warnings/CMakeLists.txt
@@ -6,7 +6,7 @@ function (add_warnings_test test_name options pass_re fail_re)
     NAME oeedger8r_${test_name}
     COMMAND oeedger8r --header-only --search-path ${CMAKE_CURRENT_SOURCE_DIR}
             -D${test_name} ${options} warnings.edl)
-  if (${fail_re})
+  if (fail_re)
     set_tests_properties(
       oeedger8r_${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "${pass_re}"
                                         FAIL_REGULAR_EXPRESSION "${fail_re}")
@@ -20,7 +20,7 @@ function (add_werror_test test_name options pass_re fail_re)
   add_test(NAME oeedger8r_${test_name}
            COMMAND oeedger8r --header-only --search-path
                    ${CMAKE_CURRENT_SOURCE_DIR} ${options} werror.edl)
-  if (${fail_re})
+  if (fail_re)
     set_tests_properties(
       oeedger8r_${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "${pass_re}"
                                         FAIL_REGULAR_EXPRESSION "${fail_re}")
@@ -167,6 +167,20 @@ add_warnings_test(
   "-Wforeign-type-ptr"
   ""
   "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+)
+
+add_warnings_test(
+  NON_FOREIGN_TYPE_PTR_TYPE3
+  "-Wforeign-type-ptr"
+  ""
+  "warning: .* Function 'func': 's' is a pointer of a foreign type .* that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+)
+
+add_warnings_test(
+  NON_FOREIGN_TYPE_PTR_TYPE4
+  "-Wforeign-type-ptr"
+  ""
+  "warning: .* Function 'func': 's' is a pointer of a foreign type .* that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
 )
 
 add_werror_test(

--- a/test/warnings/warnings.edl
+++ b/test/warnings/warnings.edl
@@ -110,5 +110,11 @@ enclave
 #ifdef NON_FOREIGN_TYPE_PTR_TYPE2
         void func(MyStruct* s);
 #endif
+#ifdef NON_FOREIGN_TYPE_PTR_TYPE3
+        void func(void* s);
+#endif
+#ifdef NON_FOREIGN_TYPE_PTR_TYPE4
+        void func(size_t* s);
+#endif
     };
 };


### PR DESCRIPTION
Update the check to avoid treating built-in types (e.g., size_t, void) as foreign types.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>