### PR TITLE
Refactor warning mechanisms

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,12 +22,18 @@ static Warning parse_warning_option(std::string& warning)
         return Warning::Error;
     else if (warning == "foreign-type-ptr")
         return Warning::ForeignTypePtr;
+    else if (warning == "non-portable-type")
+        return Warning::NonPortableType;
     else if (warning == "ptr-in-struct")
         return Warning::PtrInStruct;
     else if (warning == "ptr-in-function")
         return Warning::PtrInFunction;
+    else if (warning == "unsupported-allow")
+        return Warning::UnsupportedAllow;
     else if (warning == "return-ptr")
         return Warning::ReturnPtr;
+    else if (warning == "signed-size-or-count")
+        return Warning::SignedSizeOrCount;
     else
         return Warning::Unknown;
 }
@@ -44,6 +50,18 @@ bool operator>(WarningState l, WarningState r)
     if (l == WarningState::Error && r == WarningState::Warning)
         return true;
     return false;
+}
+
+static void set_default_warning_options(
+    std::unordered_map<Warning, WarningState, WarningHash>& warnings)
+{
+    /* Initialize the two special warning options. */
+    warnings[Warning::Error] = WarningState::Unknown;
+    warnings[Warning::All] = WarningState::Unknown;
+
+    /* Turn on the following options by default. */
+    warnings[Warning::NonPortableType] = WarningState::Warning;
+    warnings[Warning::SignedSizeOrCount] = WarningState::Warning;
 }
 
 static void _ensure_directory(const std::string& dir)
@@ -65,31 +83,35 @@ const char* usage =
     "usage: oeedger8r [options] <file> ...\n"
     "\n"
     "[options]\n"
-    "--search-path <path>  Specify the search path of EDL files\n"
-    "--use-prefix          Prefix untrusted proxy with Enclave name\n"
-    "--header-only         Only generate header files\n"
-    "--untrusted           Generate untrusted proxy and bridge\n"
-    "--trusted             Generate trusted proxy and bridge\n"
-    "--untrusted-dir <dir> Specify the directory for saving untrusted code\n"
-    "--trusted-dir   <dir> Specify the directory for saving trusted code\n"
-    "-D<name>              Define the name to be used by the C-style "
+    "--search-path <path>   Specify the search path of EDL files\n"
+    "--use-prefix           Prefix untrusted proxy with Enclave name\n"
+    "--header-only          Only generate header files\n"
+    "--untrusted            Generate untrusted proxy and bridge\n"
+    "--trusted              Generate trusted proxy and bridge\n"
+    "--untrusted-dir <dir>  Specify the directory for saving untrusted code\n"
+    "--trusted-dir   <dir>  Specify the directory for saving trusted code\n"
+    "-D<name>               Define the name to be used by the C-style "
     "preprocessor\n"
-    "-W<warning>           Enable the specified warning\n"
-    "-Wforeign-type-ptr    Warn if a function includes the pointer of a "
+    "-W<warning>            Enable the specified warning\n"
+    "-Wunsupported-allow    Warn if an untrusted function uses the unsupported "
+    "allow syntax\n"
+    "-Wforeign-type-ptr     Warn if a function includes the pointer of a "
     "foreign type\n"
-    "                      as a parameter.\n"
-    "-Wptr-in-function     Warn if a function includes a pointer as a "
+    "                       as a parameter.\n"
+    "-Wnon-portable-type    Warn if a function includes a non-portable type."
+    "-Wsigned-size-or-count Warn if a size or count parameter is signed."
+    "-Wptr-in-function      Warn if a function includes a pointer as a "
     "parameter without\n"
-    "                      a direction attribute.\n"
-    "-Wptr-in-struct       Warn if a struct includes a pointer type as a "
+    "                       a direction attribute.\n"
+    "-Wptr-in-struct        Warn if a struct includes a pointer type as a "
     "member\n"
-    "-Wreturn-ptr          Warn if a function returns a pointer type\n"
-    "-Wno-<warning>        Disable the specified warning\n"
-    "-Wall                 Enable all the available warnings\n"
-    "-Werror               Turn warnings into errors\n"
-    "-Werror=<warning>     Turn the specified warning into an error\n"
-    "--experimental        Enable experimental features\n"
-    "--help                Print this help message\n"
+    "-Wreturn-ptr           Warn if a function returns a pointer type\n"
+    "-Wno-<warning>         Disable the specified warning\n"
+    "-Wall                  Enable all the available warnings\n"
+    "-Werror                Turn warnings into errors\n"
+    "-Werror=<warning>      Turn the specified warning into an error\n"
+    "--experimental         Enable experimental features\n"
+    "--help                 Print this help message\n"
     "\n"
     "If neither `--untrusted' nor `--trusted' is specified, generate both.\n";
 
@@ -127,9 +149,8 @@ int main(int argc, char** argv)
         return fix_path_separators(argv[i]);
     };
 
-    /* Initialize the two special warning options. */
-    warnings[Warning::Error] = WarningState::Unknown;
-    warnings[Warning::All] = WarningState::Unknown;
+    /* Initialize the warning options. */
+    set_default_warning_options(warnings);
 
     while (i < argc)
     {

--- a/src/parser.h
+++ b/src/parser.h
@@ -91,10 +91,19 @@ class Parser
     void append_include(const std::string& inc);
     void append_type(UserType* type);
     void append_function(std::vector<Function*>& funcs, Function* f);
-    void warn_allow_list(const std::string& fname);
-    void warn_non_portable(Function* f);
+    void warn_or_err(Warning option, Token* token, const char* fmt, ...);
+    void warn_unsupported_allow(const std::string& fname);
+    void check_non_portable_type(Function* function);
+    void warn_non_portable_type(
+        const std::string& fname,
+        const std::string& type);
     void warn_function_return_ptr(const std::string& fname, Type* t);
     void warn_ptr_in_local_struct(const std::string& sname, Decl* d);
+    void warn_signed_size_or_count(
+        Token* token,
+        const std::string& type,
+        const std::string& name,
+        const std::string& param);
     void check_function_param(const std::string& fname, Decl* d);
     void warn_foreign_ptr(
         const std::string& fname,

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -9,9 +9,12 @@ enum class Warning
     All,
     Error,
     ForeignTypePtr,
+    NonPortableType,
     PtrInStruct,
     PtrInFunction,
     ReturnPtr,
+    SignedSizeOrCount,
+    UnsupportedAllow,
     Unknown
 };
 

--- a/test/attributes/CMakeLists.txt
+++ b/test/attributes/CMakeLists.txt
@@ -165,12 +165,12 @@ add_attributes_test(SIZE_PLAIN_TYPE "`size' is invalid for plain type `mytype'"
                     "")
 
 add_attributes_test(COUNT_INVALID_PROP1
-                    "could not find declaration for 'count_prop'" "")
+                    "could not find declaration for `count_prop'" "")
 
 add_attributes_test(COUNT_INVALID_PROP2 "size/count has invalid type" "")
 
 add_attributes_test(SIZE_INVALID_PROP1
-                    "could not find declaration for 'size_prop'" "")
+                    "could not find declaration for `size_prop'" "")
 
 add_attributes_test(SIZE_INVALID_PROP2 "size/count has invalid type" "")
 
@@ -230,17 +230,17 @@ add_attributes_test(STRUCT_SIZE_PLAIN_TYPE
                     "`size' is invalid for plain type `mytype'" "")
 
 add_attributes_test(STRUCT_COUNT_INVALID_PROP1
-                    "could not find declaration for 'p_count'" "")
+                    "could not find declaration for `p_count'" "")
 
 add_attributes_test(STRUCT_COUNT_INVALID_PROP2 "size/count has invalid type" "")
 
 add_attributes_test(STRUCT_COUNT_INVALID_PROP3
-                    "could not find declaration for 'p_count'" "")
+                    "could not find declaration for `p_count'" "")
 
 add_attributes_test(STRUCT_SIZE_INVALID_PROP1
-                    "could not find declaration for 'p_size'" "")
+                    "could not find declaration for `p_size'" "")
 
 add_attributes_test(STRUCT_SIZE_INVALID_PROP2 "size/count has invalid type" "")
 
 add_attributes_test(STRUCT_SIZE_INVALID_PROP3
-                    "could not find declaration for 'p_size'" "")
+                    "could not find declaration for `p_size'" "")

--- a/test/behavior/CMakeLists.txt
+++ b/test/behavior/CMakeLists.txt
@@ -17,71 +17,81 @@ endfunction ()
 # `private` specified should generate warning.
 add_behavior_test(
   oeedger8r_private_trusted_warning private_trusted.edl
-  "error: Function 'private': 'private' specifier is not supported by oeedger8r"
+  "error: Function `private': `private' specifier is not supported by oeedger8r"
   "")
 
-# `allow` list should generate warning.
+# `allow` in an ECALL should cause an error.
 add_behavior_test(
-  oeedger8r_allow_list_warning
-  allow_list.edl
-  "Warning: Function 'ocall_allow': Reentrant ocalls are not supported by Open Enclave. Allow list ignored."
-  "")
+  oeedger8r_allow_list_error allow_list.edl
+  "error: .* the `allow' syntax is invalid for a trusted function .ECALL." "")
 
 # These need to be separate tests to ensure that each type, for both
 # trusted and untrusted functions, generate the appropriate warning,
 # but we can reuse the EDL file.
 add_behavior_test(oeedger8r_portability_trusted_wchar_t_warning portability.edl
-                  "Function 'ocall': wchar_t has different sizes" "")
+                  "Function `ocall': `wchar_t' has different sizes" "")
 
 add_behavior_test(
   oeedger8r_portability_trusted_long_double_warning portability.edl
-  "Function 'ocall': long double has different sizes" "")
+  "Function `ocall': `long double' has different sizes" "")
 
 add_behavior_test(oeedger8r_portability_trusted_long_warning portability.edl
-                  "Function 'ocall': long has different sizes" "")
+                  "Function `ocall': `long' has different sizes" "")
 
 add_behavior_test(
   oeedger8r_portability_trusted_unsigned_long_warning portability.edl
-  "Function 'ocall': unsigned long has different sizes" "")
+  "Function `ocall': `unsigned long' has different sizes" "")
 
 add_behavior_test(
   oeedger8r_portability_untrusted_wchar_t_warning portability.edl
-  "Function 'ecall': wchar_t has different sizes" "")
+  "Function `ecall': `wchar_t' has different sizes" "")
 
 add_behavior_test(
   oeedger8r_portability_untrusted_long_double_warning portability.edl
-  "Function 'ecall': long double has different sizes" "")
+  "Function `ecall': `long double' has different sizes" "")
 
 add_behavior_test(oeedger8r_portability_untrusted_long_warning portability.edl
-                  "Function 'ecall': long has different sizes" "")
+                  "Function `ecall': `long' has different sizes" "")
 
 add_behavior_test(
   oeedger8r_portability_untrusted_unsigned_long_double_warning portability.edl
-  "Function 'ecall': unsigned long has different sizes" "")
+  "Function `ecall': `unsigned long' has different sizes" "")
 
 # Test signedness of size and count
 add_behavior_test(
   oeedger8r_size_signedness_warning
   size_signedness.edl
-  "Warning: Function 'signed_size': Size or count parameter 'size' should not be signed."
-  "Warning: Function 'unsigned_size': Size or count parameter 'size' should not be signed."
+  "warning: .* Function `signed_size': The size or count parameter `size' should not be signed"
+  "warning: .* Function `unsigned_size': The size or count parameter `size' should not be signed"
 )
+
+add_behavior_test(
+  oeedger8r_size_signedness_struct_warning
+  size_signedness.edl
+  "warning: .* struct `MyStruct': The size or count parameter `size' should not be signed"
+  "")
 
 add_behavior_test(
   oeedger8r_count_signedness_warning
   count_signedness.edl
-  "Warning: Function 'signed_count': Size or count parameter 'count' should not be signed."
-  "Warning: Function 'unsigned_count': Size or count parameter 'count' should not be signed."
+  "warning: .* Function `signed_count': The size or count parameter `count' should not be signed"
+  "warning: .* Function `unsigned_count': The size or count parameter `count' should not be signed"
 )
+
+add_behavior_test(
+  oeedger8r_count_signedness_struct_warning
+  count_signedness.edl
+  "warning: .* struct `MyStruct': The size or count parameter `count' should not be signed"
+  "")
 
 add_behavior_test(
   oeedger8r_size_and_count_warning
   size_and_count.edl
-  "Function 'size_and_count': simultaneous 'size' and 'count' parameters 'size' and 'count' are not supported by oeedger8r."
+  "Function `size_and_count': simultaneous `size' and `count' parameters `size' and `count' are not supported by oeedger8r."
   "")
 
 add_behavior_test(
   oeedger8r_deepcopy_value_warning
   deepcopy_value.edl
-  "error: the structure declaration \"MyStruct\" specifies a deep copy is expected. Referenced by value in function \"deepcopy_value\" detected."
+  "error: the structure declaration `MyStruct' specifies a deep copy is expected. Referenced by value in function `deepcopy_value' detected."
   "")

--- a/test/behavior/allow_list.edl
+++ b/test/behavior/allow_list.edl
@@ -3,15 +3,6 @@
 
 enclave {
     trusted {
-        // Normally this would be `private`, but that is also not
-        // supported, so we need to make this public in order to test
-        // the next code.
-        public void ecall();
-    };
-
-    untrusted {
-        // Allow lists are not supported. NOTE: `allow` is reserved as
-        // a keyword, so the function cannot also be named `allow()`.
-        void ocall_allow() allow(ecall);
+        public void ecall_allow() allow(ocall);
     };
 };

--- a/test/behavior/count_signedness.edl
+++ b/test/behavior/count_signedness.edl
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 
 enclave {
+    struct MyStruct {
+        int count;
+        [count = count] char* buf;
+    };
+
     trusted {
         // Signed count should generate a warning.
         public void signed_count(

--- a/test/behavior/size_signedness.edl
+++ b/test/behavior/size_signedness.edl
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 
 enclave {
+    struct MyStruct {
+        int size;
+        [size = size] char* buf;
+    };
+
     trusted {
         // Signed size should generate a warning.
         public void signed_size(

--- a/test/import/CMakeLists.txt
+++ b/test/import/CMakeLists.txt
@@ -80,7 +80,7 @@ add_test(
           --search-path ${CMAKE_CURRENT_SOURCE_DIR}/import_dir2)
 set_tests_properties(
   oeedger8r_import_search_path_order1
-  PROPERTIES PASS_REGULAR_EXPRESSION "Warning: Function 'import_dir1_ecall'")
+  PROPERTIES PASS_REGULAR_EXPRESSION "warning: Function `import_dir1_ecall'")
 
 # Ensure that a.edl is picked up from first search-path. Warning will be raised
 # for function import_dir2_ecall.
@@ -90,7 +90,7 @@ add_test(
           --search-path ${CMAKE_CURRENT_SOURCE_DIR}/import_dir1)
 set_tests_properties(
   oeedger8r_import_search_path_order2
-  PROPERTIES PASS_REGULAR_EXPRESSION "Warning: Function 'import_dir2_ecall'")
+  PROPERTIES PASS_REGULAR_EXPRESSION "warning: Function `import_dir2_ecall'")
 
 # Lockdown printing of imported file being processed.
 add_test(

--- a/test/warnings/CMakeLists.txt
+++ b/test/warnings/CMakeLists.txt
@@ -30,279 +30,307 @@ function (add_werror_test test_name options pass_re fail_re)
   endif ()
 endfunction ()
 
+# Warning tests
+
 add_warnings_test(
   PTR_IN_STRUCT
   "-Wptr-in-struct"
-  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "warning: .* struct `MyStruct': The member `p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
   "")
 
 add_warnings_test(
   NO_PTR_IN_STRUCT
   "-Wptr-in-struct"
   ""
-  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "warning: .* struct `MyStruct': The member `p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
 )
 
 add_warnings_test(
   WALL_PTR_IN_STRUCT
   "-Wall"
-  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "warning: .* struct `MyStruct': The member `p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
   "")
 
 add_warnings_test(
   WALL_NO_PTR_IN_STRUCT
   "-Wall;-Wno-ptr-in-struct"
   ""
-  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "warning: .* struct `MyStruct': The member `p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
 )
 
 add_warnings_test(
   RETURN_PTR_TYPE1
   "-Wreturn-ptr"
-  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "warning: .* Function `func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
   "")
 
 add_warnings_test(
   RETURN_PTR_TYPE2
   "-Wreturn-ptr"
-  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "warning: .* Function `func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
   "")
 
 add_warnings_test(
   RETURN_PTR_TYPE3
   "-Wreturn-ptr"
-  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "warning: .* Function `func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
   "")
 
 add_warnings_test(
   WALL_RETURN_PTR
   "-Wall"
-  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "warning: .* Function `func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
   "")
 
 add_warnings_test(
   WALL_NO_RETURN_PTR
   "-Wall;-Wno-return-ptr"
   ""
-  "warning: .* Function 'func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "warning: .* Function `func': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
 )
 
 add_warnings_test(
   PTR_IN_FUNCTION_TYPE1
   "-Wptr-in-function"
-  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "warning: .* Function `func': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
   "")
 
 add_warnings_test(
   PTR_IN_FUNCTION_TYPE2
   "-Wptr-in-function"
-  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "warning: .* Function `func': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
   "")
 
 add_warnings_test(
   PTR_IN_FUNCTION_TYPE3
   "-Wptr-in-function"
-  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "warning: .* Function `func': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
   "")
 
 add_warnings_test(
   PTR_IN_FUNCTION_TYPE4
   "-Wptr-in-function"
-  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "warning: .* Function `func': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
   "")
 
 add_warnings_test(
   WALL_PTR_IN_FUNCTION
   "-Wall"
-  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "warning: .* Function `func': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
   "")
 
 add_warnings_test(
   WALL_NO_PTR_IN_FUNCTION
   "-Wall;-Wno-ptr-in-function"
   ""
-  "warning: .* Function 'func': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "warning: .* Function `func': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
 )
 
 add_warnings_test(
   FOREIGN_TYPE_PTR_TYPE1
   "-Wforeign-type-ptr"
-  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `func': `s' is a pointer of a foreign type `MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
   "")
 
 add_warnings_test(
   FOREIGN_TYPE_PTR_TYPE2
   "-Wforeign-type-ptr"
-  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `func': `s' is a pointer of a foreign type `MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
   "")
 
 add_warnings_test(
   FOREIGN_TYPE_PTR_TYPE3
   "-Wforeign-type-ptr"
-  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `func': `s' is a pointer of a foreign type `MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
   "")
 
 add_warnings_test(
   WALL_FOREIGN_TYPE_PTR
   "-Wall"
-  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `func': `s' is a pointer of a foreign type `MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
   "")
 
 add_warnings_test(
   WALL_NO_FOREIGN_TYPE_PTR
   "-Wall;-Wno-foreign-type-ptr"
   ""
-  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `func': `s' is a pointer of a foreign type `MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
 )
 
 add_warnings_test(
   NON_FOREIGN_TYPE_PTR_TYPE1
   "-Wforeign-type-ptr"
   ""
-  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `func': `s' is a pointer of a foreign type `MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
 )
 
 add_warnings_test(
   NON_FOREIGN_TYPE_PTR_TYPE2
   "-Wforeign-type-ptr"
   ""
-  "warning: .* Function 'func': 's' is a pointer of a foreign type 'MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `func': `s' is a pointer of a foreign type `MyStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
 )
 
 add_warnings_test(
   NON_FOREIGN_TYPE_PTR_TYPE3
   "-Wforeign-type-ptr"
   ""
-  "warning: .* Function 'func': 's' is a pointer of a foreign type .* that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `func': `s' is a pointer of a foreign type .* that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
 )
 
 add_warnings_test(
   NON_FOREIGN_TYPE_PTR_TYPE4
   "-Wforeign-type-ptr"
   ""
-  "warning: .* Function 'func': 's' is a pointer of a foreign type .* that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `func': `s' is a pointer of a foreign type .* that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
 )
+
+add_warnings_test(
+  UNSUPPORTED_ALLOW_TYPE1
+  "-Wunsupported-allow"
+  "warning: .* Function `func': the `allow' syntax is currently unsupported. Ignored .-Wunsupported-allow."
+  "")
+
+add_warnings_test(
+  UNSUPPORTED_ALLOW_TYPE2
+  "-Wunsupported-allow"
+  "warning: .* Function `func': the `allow' syntax is currently unsupported. Ignored .-Wunsupported-allow."
+  "")
+
+# Werror tests
 
 add_werror_test(
   WERROR_RETURN_PTR
   "-Werror;-Wreturn-ptr"
-  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "error: .* Function `foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
   "")
 
 add_werror_test(
   WERROR_EQUAL_TO_RETURN_PTR_TYPE1
   "-Werror=return-ptr"
-  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "error: .* Function `foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
   "")
 
 add_werror_test(
   WERROR_EQUAL_TO_RETURN_PTR_TYPE2
   "-Wreturn-ptr;-Werror=return-ptr"
-  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "error: .* Function `foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
   "")
 
 add_werror_test(
   WERROR_NO_RETURN_PTR_TYPE1
   "-Werror;-Wreturn-ptr;-Wno-return-ptr"
   ""
-  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "error: .* Function `foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
 )
 
 add_werror_test(
   WERROR_NO_RETURN_PTR_TYPE2
   "-Werror=return-ptr;-Wno-return-ptr"
   ""
-  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "error: .* Function `foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
 )
 
 add_werror_test(
   WERROR_NO_RETURN_PTR_TYPE3
   "-Wreturn-ptr;-Werror=return-ptr;-Wno-return-ptr"
   ""
-  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "error: .* Function `foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
 )
 
 add_werror_test(
   NO_WERROR_RETURN_PTR
   "-Werror;-Wreturn-ptr;-Wno-error"
-  "warning: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
-  "error: .* Function 'foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "warning: .* Function `foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
+  "error: .* Function `foo': The function returns a pointer, which could expose memory addresses across the host-enclave boundary. Consider passing the pointer as an out parameter instead .-Wreturn-ptr."
 )
 
 add_werror_test(
   WERROR_PTR_IN_STRUCT
   "-Werror;-Wptr-in-struct"
-  "error: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "error: .* struct `MyStruct': The member `p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
   "")
 
 add_werror_test(
   WERROR_EQUAL_TO_PTR_IN_STRUCT
   "-Werror=ptr-in-struct"
-  "error: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "error: .* struct `MyStruct': The member `p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
   "")
 
 add_werror_test(
   WERROR_NO_PTR_IN_STRUCT
   "-Werror;-Wptr-in-struct;-Wno-ptr-in-struct"
   ""
-  "error: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "error: .* struct `MyStruct': The member `p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
 )
 
 add_werror_test(
   NO_WERROR_PTR_IN_STRUCT
   "-Werror;-Wptr-in-struct;-Wno-error"
-  "warning: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
-  "error: .* struct 'MyStruct': The member 'p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "warning: .* struct `MyStruct': The member `p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
+  "error: .* struct `MyStruct': The member `p' is a pointer that is not serializable. Consider annotating the member with the `count' or `size' attribute .-Wptr-in-struct."
 )
 
 add_werror_test(
   WERROR_PTR_IN_FUNCTION
   "-Werror;-Wptr-in-function"
-  "error: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "error: .* Function `bar': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
   "")
 
 add_werror_test(
   WERROR_EQUAL_TO_PTR_IN_FUNCTION
   "-Werror=ptr-in-function"
-  "error: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "error: .* Function `bar': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
   "")
 
 add_werror_test(
   WERROR_NO_PTR_IN_FUNCTION
   "-Werror;-Wptr-in-function;-Wno-ptr-in-function"
   ""
-  "error: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "error: .* Function `bar': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
 )
 
 add_werror_test(
   NO_WERROR_PTR_IN_FUNCTION
   "-Werror;-Wptr-in-function;-Wno-error"
-  "warning: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
-  "error: .* Function 'bar': 's' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "warning: .* Function `bar': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
+  "error: .* Function `bar': `s' is a pointer that is not serializable. Consider annotating the parameter with the direction annotation .-Wptr-in-function."
 )
 
 add_werror_test(
   WERROR_FOREIGN_TYPE_PTR
   "-Werror;-Wforeign-type-ptr"
-  "error: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "error: .* Function `bar': `s' is a pointer of a foreign type `TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
   "")
 
 add_werror_test(
   WERROR_EQUAL_TO_FOREIGN_TYPE_PTR
   "-Werror=foreign-type-ptr"
-  "error: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "error: .* Function `bar': `s' is a pointer of a foreign type `TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
   "")
 
 add_werror_test(
   WERROR_NO_FOREIGN_TYPE_PTR
   "-Werror;-Wforeign-type-ptr;-Wno-foreign-type-ptr"
   ""
-  "error: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "error: .* Function `bar': `s' is a pointer of a foreign type `TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
 )
 
 add_werror_test(
   NO_WERROR_FOREIGN_TYPE_PTR
   "-Werror;-Wforeign-type-ptr;-Wno-error"
-  "warning: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
-  "error: .* Function 'bar': 's' is a pointer of a foreign type 'TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "warning: .* Function `bar': `s' is a pointer of a foreign type `TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
+  "error: .* Function `bar': `s' is a pointer of a foreign type `TestStruct' that may not be serializable. Consider defining the type in the EDL file with proper annotations .-Wforeign-type-ptr."
 )
+
+add_werror_test(
+  WERROR_UNSUPPOTED_ALLOW
+  "-Werror;-Wunsupported-allow"
+  "error: .* Function `baz': the `allow' syntax is currently unsupported. Ignored .-Wunsupported-allow."
+  "")
+
+add_werror_test(
+  WERROR_EQUAL_TO_UNSUPPORTED_ALLOW
+  "-Werror=unsupported-allow"
+  "error: .* Function `baz': the `allow' syntax is currently unsupported. Ignored .-Wunsupported-allow."
+  "")

--- a/test/warnings/warnings.edl
+++ b/test/warnings/warnings.edl
@@ -116,5 +116,18 @@ enclave
 #ifdef NON_FOREIGN_TYPE_PTR_TYPE4
         void func(size_t* s);
 #endif
+
+#ifdef UNSUPPORTED_ALLOW_TYPE1
+        // The `allow` keyword allows an ECALL be declared as private and is used
+        // only by the OCALL using the keyword. However, the keyword is currently
+        // not supported.
+        void func() allow(ecall);
+#endif
+#ifdef UNSUPPORTED_ALLOW_TYPE2
+        // The `allow` keyword allows an ECALL be declared as private and is used
+        // only by the OCALL using the keyword. However, the keyword is currently
+        // not supported.
+        void func() allow(ecall1, ecall2, ecall3);
+#endif
     };
 };

--- a/test/warnings/werror.edl
+++ b/test/warnings/werror.edl
@@ -5,7 +5,7 @@ enclave
 {
     struct MyStruct
     {
-       size_t size;
+       int size;
        int* p;
     };
 
@@ -16,5 +16,7 @@ enclave
         void bar(TestStruct* s);
 
         void abc(int* s);
+
+        void baz() allow(ecall);
     };
 };


### PR DESCRIPTION
The PR refactors the warning mechanisms based on #67. More specifically, the PR does the following:
- Make the warning messages consistent
  - Use the backtick (`) and the single quote mark (') to quote the keyword/name.
  - Use same format for previous warning messages
- Provide options to existing warnings
   - Add `-Wnon-portable-type`, `-Wsigned-size-or-count`, and `-Wunsupported-allow` options
   - `-Wnon-portable-type` and `-Wsigned-size-or-count` are turned on by default, which retains the existing behavior.
- Explicitly error out the use of `allow` syntax in trusted functions.
- Add more test cases

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>