### PR TITLE
Remove the deepcopy out experimental flag

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1437,20 +1437,6 @@ void Parser::validate_attributes(Decl* d)
 
             if (d->type_->tag_ == Ptr)
             {
-                UserType* ut = get_user_type_for_deep_copy(types_, d);
-                if (ut)
-                {
-                    /* Deep-copy out parameter is currently an experimental
-                     * feature. */
-                    if (!experimental_ && in_function_ && attrs->out_ &&
-                        !attrs->inout_)
-                        ERROR_AT(
-                            itr.second,
-                            "`out' for user defined type `%s' requires the "
-                            "--experimental option",
-                            atype_str(type).c_str());
-                }
-
                 if (d->dims_)
                 {
                     ERROR_AT(

--- a/test/attributes/CMakeLists.txt
+++ b/test/attributes/CMakeLists.txt
@@ -135,11 +135,6 @@ add_attributes_test(OUT_TYPE1 "unexpected pointer attributes for `int'" "")
 
 add_attributes_test(OUT_TYPE2 "`out' is invalid for plain type `mytype'" "")
 
-add_attributes_test(
-  OUT_USER_TYPE_PTR
-  "`out' for user defined type `MyStruct\\*' requires the --experimental option"
-  "")
-
 add_attributes_test(IN_USER_TYPE_PTR_ARRAY
                     "invalid parameter - `s' is a pointer array" "")
 

--- a/test/attributes/attributes.edl
+++ b/test/attributes/attributes.edl
@@ -122,9 +122,6 @@ enclave
 #ifdef OUT_TYPE2
         void func([out] mytype x);
 #endif
-#ifdef OUT_USER_TYPE_PTR
-        void func([out] MyStruct* s);
-#endif
 #ifdef IN_USER_TYPE_PTR_ARRAY
         void func([in] MyStruct* s[8]);
 #endif

--- a/test/comprehensive/enc/CMakeLists.txt
+++ b/test/comprehensive/enc/CMakeLists.txt
@@ -16,10 +16,8 @@ add_custom_command(
           ../edl/string.edl
           ../edl/struct.edl
           ../edl/switchless.edl
-  COMMAND
-    oeedger8r --experimental --trusted --search-path
-    ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path
-    ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
+  COMMAND oeedger8r --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl
+          --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
 add_custom_command(
   OUTPUT bar_t.h bar_args.h

--- a/test/comprehensive/host/CMakeLists.txt
+++ b/test/comprehensive/host/CMakeLists.txt
@@ -17,9 +17,8 @@ add_custom_command(
           ../edl/struct.edl
           ../edl/switchless.edl
   COMMAND
-    oeedger8r --experimental --untrusted --search-path
-    ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path
-    ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
+    oeedger8r --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl
+    --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
 add_custom_command(
   OUTPUT bar_u.h bar_args.h


### PR DESCRIPTION
Remove the experimental flag for deepcopy out feature. This allows us starting to refactor the OE runtime.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>