### PR TITLE
Set count to one by default and prevent the use of size for user-defined

### DIFF
--- a/src/f_emitter.h
+++ b/src/f_emitter.h
@@ -535,7 +535,7 @@ class FEmitter
             if (!ut || !p->attrs_->out_ || p->attrs_->inout_)
                 continue;
 
-            std::string count = count_attr_str(p->attrs_->count_, "_");
+            std::string count = count_attr_str(p->attrs_->count_, prefix);
             std::string cmd = "OE_WRITE_DEEPCOPY_OUT_PARAM";
             std::string mt = mtype_str(p);
 
@@ -578,8 +578,7 @@ class FEmitter
          */
         out() << indent + "if (" + lhs_expr + ")" << indent + "{";
         {
-            std::string count =
-                count_attr_str(p->attrs_->count_, parent_rhs_expr);
+            std::string count = pcount(p, parent_rhs_expr);
             std::string idx = "_i_" + to_str(level);
 
             out() << indent + "    for (size_t " + idx + " = 0; " + idx +

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1437,6 +1437,17 @@ void Parser::validate_attributes(Decl* d)
 
             if (d->type_->tag_ == Ptr)
             {
+                UserType* ut = get_user_type_for_deep_copy(types_, d);
+                if (ut)
+                {
+                    if (!attrs->size_.is_empty())
+                        ERROR_AT(
+                            itr.second,
+                            "size attributes are invalid for the pointer of an "
+                            "user-defined type `%s'",
+                            ut->name_.c_str());
+                }
+
                 if (d->dims_)
                 {
                     ERROR_AT(

--- a/src/utils.h
+++ b/src/utils.h
@@ -244,14 +244,8 @@ inline std::string pcount(Decl* p, const std::string& prefix = "")
     if (p->type_->tag_ == Foreign && p->attrs_ && p->attrs_->isary_)
         return "1";
 
-    if (!p->attrs_->size_.is_empty() && !p->attrs_->count_.is_empty())
-        return count_attr_str(p->attrs_->size_, prefix);
-
     if (p->attrs_ && !p->attrs_->count_.is_empty())
         return count_attr_str(p->attrs_->count_, prefix);
-
-    if (p->attrs_ && !p->attrs_->size_.is_empty())
-        return "1";
 
     return "1";
 }
@@ -270,12 +264,6 @@ inline std::string psize(Decl* p, const std::string& prefix = "")
         s = "sizeof(" + replace(atype_str(p->type_->t_), "const ", "") + ")";
     else if (p->type_->tag_ == Foreign && p->attrs_ && p->attrs_->isptr_)
         s = "sizeof(*(" + p->type_->name_ + ")0)";
-
-    if (!p->attrs_->size_.is_empty() && !p->attrs_->count_.is_empty())
-        return size_attr_str(p->attrs_->count_, prefix);
-
-    if (p->attrs_ && !p->attrs_->count_.is_empty())
-        return s;
 
     if (p->attrs_ && !p->attrs_->size_.is_empty())
         return size_attr_str(p->attrs_->size_, prefix);

--- a/src/w_emitter.h
+++ b/src/w_emitter.h
@@ -522,11 +522,10 @@ class WEmitter
                 << indent + "    OE_ADD_ARG_SIZE(_output_buffer_offset, " +
                        argcount + ", " + argsize + ");";
 
-            std::string count = count_attr_str(p->attrs_->count_, parent_expr);
             std::string idx = "_i_" + to_str(level);
 
             out() << indent + "    for (size_t " + idx + " = 0; " + idx +
-                         " < " + count + "; " + idx + "++)"
+                         " < " + argcount + "; " + idx + "++)"
                   << indent + "    {";
 
             /* First iteration: Find struct members that are not user-defined
@@ -649,7 +648,7 @@ class WEmitter
     void unmarshal_deep_copy_out(Decl* p)
     {
         std::string cmd = "OE_SET_DEEPCOPY_OUT_PARAM";
-        std::string count = count_attr_str(p->attrs_->count_, "_");
+        std::string count = count_attr_str(p->attrs_->count_);
         std::string mt = mtype_str(p);
 
         if (count == "1" || count == "")

--- a/test/attributes/CMakeLists.txt
+++ b/test/attributes/CMakeLists.txt
@@ -169,6 +169,21 @@ add_attributes_test(SIZE_INVALID_PROP1
 
 add_attributes_test(SIZE_INVALID_PROP2 "size/count has invalid type" "")
 
+add_attributes_test(
+  SIZE_USER_TYPE_IN_PTR
+  "size attributes are invalid for the pointer of an user-defined type `TestStruct'"
+  "")
+
+add_attributes_test(
+  SIZE_USER_TYPE_OUT_PTR
+  "size attributes are invalid for the pointer of an user-defined type `TestStruct'"
+  "")
+
+add_attributes_test(
+  SIZE_USER_TYPE_INOUT_PTR
+  "size attributes are invalid for the pointer of an user-defined type `TestStruct'"
+  "")
+
 # Attributes are not supported for unions.
 add_attributes_test(UNION_UNSUPPORTED "attributes are not allowed for unions"
                     "")

--- a/test/attributes/attributes.edl
+++ b/test/attributes/attributes.edl
@@ -3,13 +3,11 @@
 
 enclave
 {
-#ifdef OUT_USER_TYPE_PTR
-    struct MyStruct
+    struct TestStruct
     {
        size_t size;
        [size=size] int* p;
     };
-#endif
 
     untrusted
     {
@@ -123,13 +121,13 @@ enclave
         void func([out] mytype x);
 #endif
 #ifdef IN_USER_TYPE_PTR_ARRAY
-        void func([in] MyStruct* s[8]);
+        void func([in] TestStruct* s[8]);
 #endif
 #ifdef OUT_USER_TYPE_PTR_ARRAY
-        void func([out] MyStruct* s[8]);
+        void func([out] TestStruct* s[8]);
 #endif
 #ifdef INOUT_USER_TYPE_PTR_ARRAY
-        void func([in, out] MyStruct* s[8]);
+        void func([in, out] TestStruct* s[8]);
 #endif
 
 // Checks for count/size
@@ -159,6 +157,15 @@ enclave
 #endif
 #ifdef SIZE_INVALID_PROP2
         void func([size = size_prop, in] int* x, int* size_prop);
+#endif
+#ifdef SIZE_USER_TYPE_IN_PTR
+        void func([size = 1, in] TestStruct* x);
+#endif
+#ifdef SIZE_USER_TYPE_OUT_PTR
+        void func([size = 1, out] TestStruct* x);
+#endif
+#ifdef SIZE_USER_TYPE_INOUT_PTR
+        void func([size = 1, in, out] TestStruct* x);
 #endif
     };
 

--- a/test/comprehensive/edl/deepcopy.edl
+++ b/test/comprehensive/edl/deepcopy.edl
@@ -88,40 +88,41 @@ enclave {
 
     // Although `s` is passed by pointer, because `s.ptr` does not
     // have any attribute, it is still not deep copied.
-    public void deepcopy_shallow([in, out, count=1] ShallowStruct* s, [user_check] uint64_t* ptr);
+    public void deepcopy_shallow([in, out] ShallowStruct* s, [user_check] uint64_t* ptr);
 
     // Deep copy of one `CountStruct` with an embedded array should
     // take place.
-    public void deepcopy_count([in, out, count=1] CountStruct* s);
+    public void deepcopy_count([in, out] CountStruct* s);
 
     // Deep copy of one `CountParamStruct` with an embedded array
     // should take place.
-    public void deepcopy_countparam([in, out, count=1] CountParamStruct* s);
+    public void deepcopy_countparam([in, out] CountParamStruct* s);
 
     // TODO: We should have a `SizeStruct` to test deep copying where
     // the size attribute is correctly used with a hard-coded value.
-    public void deepcopy_size([in, out, count=1] SizeStruct* s);
-    public void deepcopy_countsize([in, out, count=1] CountSizeStruct* s);
+    public void deepcopy_size([in, out] SizeStruct* s);
+    public void deepcopy_countsize([in, out] CountSizeStruct* s);
 
     // Deep copy of one `SizeParamStruct` with an embedded array
     // should take place.
-    public void deepcopy_sizeparam([in, out, count=1] SizeParamStruct* s);
+    public void deepcopy_sizeparam([in, out] SizeParamStruct* s);
 
     // Deep copy of one `CountSizeParamStruct` with an embedded array
     // should take place.
-    public void deepcopy_countsizeparam([in, out, count=1] CountSizeParamStruct* s);
+    public void deepcopy_countsizeparam([in, out] CountSizeParamStruct* s);
 
     // Deep copy of one `CountSizeParamStruct` with an embedded array
     // should take place, tests with `size * 1`.
-    public void deepcopy_countsizeparam_size([in, out, count=1] CountSizeParamStruct* s);
+    public void deepcopy_countsizeparam_size([in, out] CountSizeParamStruct* s);
 
     // Deep copy of one `CountSizeParamStruct` with an embedded array
     // should take place, tests with `count * 1`.
-    public void deepcopy_countsizeparam_count([in, out, count=1] CountSizeParamStruct* s);
+    public void deepcopy_countsizeparam_count([in, out] CountSizeParamStruct* s);
 
     // Deep copy of two `CountParamStruct`s each with an embedded
     // array and different counts should take place.
     public void deepcopy_countparamarray([in, out, count=2] CountParamStruct* s);
+    public void deepcopy_countparamarray_n([in, out, count=n] CountParamStruct* s, size_t n);
 
     // Deep copy of two `SizeParamStruct`s each with an embedded
     // array and different sizes should take place.
@@ -132,100 +133,104 @@ enclave {
     public void deepcopy_countsizeparamarray([in, out, count=2] CountSizeParamStruct* s);
 
     // Maybe test for recursive copying.
-    public void deepcopy_nested([in, out, count=1] NestedStruct* n);
+    public void deepcopy_nested([in, out] NestedStruct* n);
 
     // Really stress the recursion.
     public void deepcopy_super_nested([in, out, count=n] SuperNestedStruct* s, size_t n);
 
     // Test handling of null values.
-    public void deepcopy_null([in, out, count=1] CountStruct* s);
+    public void deepcopy_null([in, out] CountStruct* s);
 
     // Test that it is only copied in, not out.
-    public void deepcopy_in([in, count=1] CountStruct* s);
+    public void deepcopy_in([in] CountStruct* s);
 
     // Deep copy of one `CountStruct` with an embedded array in and out
     // should take place.
-    public void deepcopy_inout_count([in, out, count=1] CountStruct* s);
+    public void deepcopy_inout_count([in, out] CountStruct* s);
 
     // Test a real-world scenario.
     public void deepcopy_iovec([in, out, count=n] IOVEC* iov, size_t n);
 
     // Expect the callee to set a large count value on return.
-    public void deepcopy_countparam_return_large([in, out, count=1] CountParamStruct* s);
+    public void deepcopy_countparam_return_large([in, out] CountParamStruct* s);
 
     // Expect the callee to set a large size value on return.
-    public void deepcopy_sizeparam_return_large([in, out, count=1] SizeParamStruct* s);
+    public void deepcopy_sizeparam_return_large([in, out] SizeParamStruct* s);
 
     // Expect the callee to set a large size and count value on return.
-    public void deepcopy_countsizeparam_return_large([in, out, count=1] CountSizeParamStruct* s);
+    public void deepcopy_countsizeparam_return_large([in, out] CountSizeParamStruct* s);
 
     // Expect the callee to set a large size and count value on return.
-    public void deepcopy_countsize_return_large([in, out, count=1] CountSizeStruct* s);
+    public void deepcopy_countsize_return_large([in, out] CountSizeStruct* s);
 
     public void test_deepcopy_ocalls();
 
-    public void deepcopy_countparam_out([out, count=1] CountParamStruct* s);
+    public void deepcopy_countparam_out([out] CountParamStruct* s);
     public void deepcopy_countparamarray_out([out, count=2] CountParamStruct* s);
+    public void deepcopy_countparamarray_n_out([out, count=n] CountParamStruct* s, size_t n);
     public void deepcopy_countparamarray_partial_out([out, count=2] CountParamStruct* s);
-    public void deepcopy_sizeparam_out([out, count=1] SizeParamStruct* s);
-    public void deepcopy_countsizeparam_out([out, count=1] CountSizeParamStruct* s);
-    public void deepcopy_countsize_out([out, count=1] CountSizeStruct* s);
-    public void deepcopy_nested_out([out, count=1] NestedStruct* n);
-    public void deepcopy_nested_countparam_out([out, count=1] CountParamNestedStruct* n);
-    public void deepcopy_multiple_nested_out([out, count=1] MultipleNestedStruct* n);
-    public void deepcopy_multiple_nested_partial_out([out, count=1] MultipleNestedStruct* n);
+    public void deepcopy_sizeparam_out([out] SizeParamStruct* s);
+    public void deepcopy_countsizeparam_out([out] CountSizeParamStruct* s);
+    public void deepcopy_countsize_out([out] CountSizeStruct* s);
+    public void deepcopy_nested_out([out] NestedStruct* n);
+    public void deepcopy_nested_countparam_out([out] CountParamNestedStruct* n);
+    public void deepcopy_multiple_nested_out([out] MultipleNestedStruct* n);
+    public void deepcopy_multiple_nested_partial_out([out] MultipleNestedStruct* n);
 
-    public void deepcopy_mix([in, count=1] SizeParamStruct* s_in,
-                             [in, out, count=1] SizeParamStruct* s_inout,
-                             [out, count=1] SizeParamStruct* s_out,
+    public void deepcopy_mix([in] SizeParamStruct* s_in,
+                             [in, out] SizeParamStruct* s_inout,
+                             [out] SizeParamStruct* s_out,
                              [user_check] SizeParamStruct* s_user_check,
-                             [out, count=1] SizeParamStruct* s_out_2);
+                             [out] SizeParamStruct* s_out_2);
   };
 
   untrusted
   {
     // Deep copy of one `CountParamStruct` with an embedded array
     // should take place.
-    void ocall_deepcopy_countparam([in, out, count=1] CountParamStruct* s);
+    void ocall_deepcopy_countparam([in, out] CountParamStruct* s);
+    void ocall_deepcopy_countparamarray([in, out, count=2] CountParamStruct* s);
+    void ocall_deepcopy_countparamarray_n([in, out, count=n] CountParamStruct* s, size_t n);
 
     // Deep copy of one `SizeParamStruct` with an embedded array
     // should take place.
-    void ocall_deepcopy_sizeparam([in, out, count=1] SizeParamStruct* s);
+    void ocall_deepcopy_sizeparam([in, out] SizeParamStruct* s);
 
     // Deep copy of two `CountSizeParamStruct`s each with an embedded
     // array and different counts should take place.
-    void ocall_deepcopy_countsizeparam([in, out, count=1] CountSizeParamStruct* s);
+    void ocall_deepcopy_countsizeparam([in, out] CountSizeParamStruct* s);
 
     // Deep copy of one `CountSizeStruct` each with an embedded
     // array should take place.
-    void ocall_deepcopy_countsize([in, out, count=1] CountSizeStruct* s);
+    void ocall_deepcopy_countsize([in, out] CountSizeStruct* s);
 
     // Expect the callee to set a large count value on return.
-    void ocall_deepcopy_countparam_return_large([in, out, count=1] CountParamStruct* s);
+    void ocall_deepcopy_countparam_return_large([in, out] CountParamStruct* s);
 
     // Expect the callee to set a large count value on return.
-    void ocall_deepcopy_sizeparam_return_large([in, out, count=1] SizeParamStruct* s);
+    void ocall_deepcopy_sizeparam_return_large([in, out] SizeParamStruct* s);
 
     // Expect the callee to set a large count value on return.
-    void ocall_deepcopy_countsizeparam_return_large([in, out, count=1] CountSizeParamStruct* s);
+    void ocall_deepcopy_countsizeparam_return_large([in, out] CountSizeParamStruct* s);
 
     // Expect the callee to set a large count value on return.
-    void ocall_deepcopy_countsize_return_large([in, out, count=1] CountSizeStruct* s);
+    void ocall_deepcopy_countsize_return_large([in, out] CountSizeStruct* s);
 
-    void ocall_deepcopy_countparam_out([out, count=1] CountParamStruct* s);
+    void ocall_deepcopy_countparam_out([out] CountParamStruct* s);
     void ocall_deepcopy_countparamarray_out([out, count=2] CountParamStruct* s);
+    void ocall_deepcopy_countparamarray_n_out([out, count=n] CountParamStruct* s, size_t n);
     void ocall_deepcopy_countparamarray_partial_out([out, count=2] CountParamStruct* s);
-    void ocall_deepcopy_sizeparam_out([out, count=1] SizeParamStruct* s);
-    void ocall_deepcopy_countsizeparam_out([out, count=1] CountSizeParamStruct* s);
-    void ocall_deepcopy_countsize_out([out, count=1] CountSizeStruct* s);
-    void ocall_deepcopy_nested_out([out, count=1] NestedStruct* n);
-    void ocall_deepcopy_nested_countparam_out([out, count=1] CountParamNestedStruct* n);
-    void ocall_deepcopy_multiple_nested_out([out, count=1] MultipleNestedStruct* n);
-    void ocall_deepcopy_multiple_nested_partial_out([out, count=1] MultipleNestedStruct* n);
-    void ocall_deepcopy_mix([in, count=1] SizeParamStruct* s_in,
-                            [in, out, count=1] SizeParamStruct* s_inout,
-                            [out, count=1] SizeParamStruct* s_out,
+    void ocall_deepcopy_sizeparam_out([out] SizeParamStruct* s);
+    void ocall_deepcopy_countsizeparam_out([out] CountSizeParamStruct* s);
+    void ocall_deepcopy_countsize_out([out] CountSizeStruct* s);
+    void ocall_deepcopy_nested_out([out] NestedStruct* n);
+    void ocall_deepcopy_nested_countparam_out([out] CountParamNestedStruct* n);
+    void ocall_deepcopy_multiple_nested_out([out] MultipleNestedStruct* n);
+    void ocall_deepcopy_multiple_nested_partial_out([out] MultipleNestedStruct* n);
+    void ocall_deepcopy_mix([in] SizeParamStruct* s_in,
+                            [in, out] SizeParamStruct* s_inout,
+                            [out] SizeParamStruct* s_out,
                             [user_check] SizeParamStruct* s_user_check,
-                            [out, count=1] SizeParamStruct* s_out_2);
+                            [out] SizeParamStruct* s_out_2);
   };
 };


### PR DESCRIPTION
This PR allows a user-defined type to have a default count equal to one if the count attribute is not specified. Also, prevent the use of size attributes with the user-defined type argument, which us not supported.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>