### PR TITLE
Support deepcopy of nested in and inout parameters

### DIFF
--- a/src/f_emitter.h
+++ b/src/f_emitter.h
@@ -203,9 +203,9 @@ class FEmitter
         iterate_deep_copyable_fields(ut, [&](Decl* prop) {
             std::string op = *parent_expr.rbegin() == ']' ? "." : "->";
             std::string expr = parent_expr + op + prop->name_;
-            std::string argcount =
-                pcount(prop, "_pargs_in->" + parent_expr + op);
-            std::string argsize = psize(prop, "_pargs_in->" + parent_expr + op);
+            std::string prefix = "_pargs_in->" + parent_expr + op;
+            std::string argcount = pcount(prop, prefix);
+            std::string argsize = psize(prop, prefix);
             std::string cond = parent_condition + " && " + (is_out ? "!" : "") +
                                "_pargs_in->" + expr;
             std::string mt = mtype_str(prop);
@@ -217,8 +217,7 @@ class FEmitter
             if (!ut)
                 return;
 
-            std::string count =
-                count_attr_str(prop->attrs_->count_, "_pargs_in->");
+            std::string count = count_attr_str(prop->attrs_->count_, prefix);
 
             if (count == "1" || count == "")
             {
@@ -233,8 +232,8 @@ class FEmitter
                 out() << indent + "for (size_t " + idx + " = 0; " + idx +
                              " < " + count + "; " + idx + "++)"
                       << indent + "{";
-                std::string cond = parent_condition + " && _pargs_in->" +
-                                   parent_expr + op + prop->name_;
+                std::string cond =
+                    parent_condition + " && " + prefix + prop->name_;
                 set_pointers_deep_copy(
                     cond, expr, cmd, prop, level + 1, indent + "    ", is_out);
                 out() << indent + "}";

--- a/src/w_emitter.h
+++ b/src/w_emitter.h
@@ -303,8 +303,9 @@ class WEmitter
         iterate_deep_copyable_fields(ut, [&](Decl* prop) {
             std::string op = *parent_expr.rbegin() == ']' ? "." : "->";
             std::string expr = parent_expr + op + prop->name_;
-            std::string argcount = pcount(prop, "_args." + parent_expr + op);
-            std::string argsize = psize(prop, "_args." + parent_expr + op);
+            std::string prefix = "_args." + parent_expr + op;
+            std::string argcount = pcount(prop, prefix);
+            std::string argsize = psize(prop, prefix);
             std::string cond = parent_condition + " && " + expr;
             out() << indent + "if (" + cond + ")"
                   << indent + "    OE_ADD_ARG_SIZE(" + buffer_size + ", " +
@@ -314,7 +315,7 @@ class WEmitter
             if (!ut)
                 return;
 
-            std::string count = count_attr_str(prop->attrs_->count_, "_args.");
+            std::string count = count_attr_str(prop->attrs_->count_, prefix);
 
             if (count == "1" || count == "")
             {
@@ -412,8 +413,9 @@ class WEmitter
         iterate_deep_copyable_fields(ut, [&](Decl* prop) {
             std::string op = *parent_expr.rbegin() == ']' ? "." : "->";
             std::string expr = parent_expr + op + prop->name_;
-            std::string argcount = pcount(prop, "_args." + parent_expr + op);
-            std::string argsize = psize(prop, "_args." + parent_expr + op);
+            std::string prefix = "_args." + parent_expr + op;
+            std::string argcount = pcount(prop, prefix);
+            std::string argsize = psize(prop, prefix);
             std::string cond = parent_condition + " && " + expr;
             std::string mt = mtype_str(prop);
             out() << indent + "if (" + cond + ")"
@@ -424,7 +426,7 @@ class WEmitter
             if (!ut)
                 return;
 
-            std::string count = count_attr_str(prop->attrs_->count_, "_args.");
+            std::string count = count_attr_str(prop->attrs_->count_, prefix);
 
             if (count == "1" || count == "")
             {
@@ -511,8 +513,6 @@ class WEmitter
          */
         out() << indent + "if (" + expr + ")" << indent + "{";
         {
-            if (!parent_expr.empty())
-                parent_expr += ".";
             std::string argcount = pcount(p, parent_expr);
             std::string argsize = psize(p, parent_expr);
             std::string p_type = atype_str(p->type_);

--- a/test/comprehensive/edl/deepcopy.edl
+++ b/test/comprehensive/edl/deepcopy.edl
@@ -182,6 +182,9 @@ enclave {
                              [out] SizeParamStruct* s_out,
                              [user_check] SizeParamStruct* s_user_check,
                              [out] SizeParamStruct* s_out_2);
+
+    public void deepcopy_nested_countparam_inout([in, out] CountParamNestedStruct* s);
+    public void deepcopy_nested_countparam_in([in] CountParamNestedStruct* s);
   };
 
   untrusted
@@ -232,5 +235,8 @@ enclave {
                             [out] SizeParamStruct* s_out,
                             [user_check] SizeParamStruct* s_user_check,
                             [out] SizeParamStruct* s_out_2);
+
+    void ocall_deepcopy_nested_countparam_inout([in, out] CountParamNestedStruct* s);
+    void ocall_deepcopy_nested_countparam_in([in] CountParamNestedStruct* s);
   };
 };

--- a/test/comprehensive/enc/testdeepcopy.cpp
+++ b/test/comprehensive/enc/testdeepcopy.cpp
@@ -736,6 +736,26 @@ void deepcopy_mix(
     set_sizeparam(s_out_2, 50, 50, 'F');
 }
 
+void deepcopy_nested_countparam_inout(CountParamNestedStruct* s)
+{
+    OE_TEST(s->num == 3);
+    check_countparam(&s->array_of_struct[0], 10, 10, 'A');
+    check_countparam(&s->array_of_struct[1], 20, 20, 'B');
+    check_countparam(&s->array_of_struct[2], 30, 30, 'C');
+
+    set_countparam(&s->array_of_struct[0], 10, 10, 'D', 0);
+    set_countparam(&s->array_of_struct[1], 20, 20, 'E', 0);
+    set_countparam(&s->array_of_struct[2], 30, 30, 'F', 0);
+}
+
+void deepcopy_nested_countparam_in(CountParamNestedStruct* s)
+{
+    OE_TEST(s->num == 3);
+    check_countparam(&s->array_of_struct[0], 10, 10, 'A');
+    check_countparam(&s->array_of_struct[1], 20, 20, 'B');
+    check_countparam(&s->array_of_struct[2], 30, 30, 'C');
+}
+
 template <typename T>
 void test_struct(const T& s, size_t size = 8, size_t offset = 0)
 {
@@ -1190,5 +1210,38 @@ void test_deepcopy_ocalls()
         free(s_inout.ptr);
         free(s_out.ptr);
         free(s_out_2.ptr);
+    }
+
+    {
+        CountParamNestedStruct s;
+        CountParamStruct ns[3];
+        s.num = 3;
+        s.array_of_struct = ns;
+
+        set_countparam(&ns[0], 10, 10, 'A', 1);
+        set_countparam(&ns[1], 20, 20, 'B', 1);
+        set_countparam(&ns[2], 30, 30, 'C', 1);
+        OE_TEST(ocall_deepcopy_nested_countparam_inout(&s) == OE_OK);
+        check_countparam(&ns[0], 10, 10, 'D');
+        check_countparam(&ns[1], 20, 20, 'E');
+        check_countparam(&ns[2], 30, 30, 'F');
+        free(ns[0].ptr);
+        free(ns[1].ptr);
+        free(ns[2].ptr);
+    }
+
+    {
+        CountParamNestedStruct s;
+        CountParamStruct ns[3];
+        s.num = 3;
+        s.array_of_struct = ns;
+
+        set_countparam(&ns[0], 10, 10, 'A', 1);
+        set_countparam(&ns[1], 20, 20, 'B', 1);
+        set_countparam(&ns[2], 30, 30, 'C', 1);
+        OE_TEST(ocall_deepcopy_nested_countparam_in(&s) == OE_OK);
+        free(ns[0].ptr);
+        free(ns[1].ptr);
+        free(ns[2].ptr);
     }
 }

--- a/test/comprehensive/host/testdeepcopy.cpp
+++ b/test/comprehensive/host/testdeepcopy.cpp
@@ -517,6 +517,26 @@ void ocall_deepcopy_mix(
     set_sizeparam(s_out_2, 50, 50, 'F');
 }
 
+void ocall_deepcopy_nested_countparam_inout(CountParamNestedStruct* s)
+{
+    OE_TEST(s->num == 3);
+    check_countparam(&s->array_of_struct[0], 10, 10, 'A');
+    check_countparam(&s->array_of_struct[1], 20, 20, 'B');
+    check_countparam(&s->array_of_struct[2], 30, 30, 'C');
+
+    set_countparam(&s->array_of_struct[0], 10, 10, 'D', 0);
+    set_countparam(&s->array_of_struct[1], 20, 20, 'E', 0);
+    set_countparam(&s->array_of_struct[2], 30, 30, 'F', 0);
+}
+
+void ocall_deepcopy_nested_countparam_in(CountParamNestedStruct* s)
+{
+    OE_TEST(s->num == 3);
+    check_countparam(&s->array_of_struct[0], 10, 10, 'A');
+    check_countparam(&s->array_of_struct[1], 20, 20, 'B');
+    check_countparam(&s->array_of_struct[2], 30, 30, 'C');
+}
+
 void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
 {
     {
@@ -1068,6 +1088,39 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         free(s_inout.ptr);
         free(s_out.ptr);
         free(s_out_2.ptr);
+    }
+
+    {
+        CountParamNestedStruct s;
+        CountParamStruct ns[3];
+        s.num = 3;
+        s.array_of_struct = ns;
+
+        set_countparam(&ns[0], 10, 10, 'A', 1);
+        set_countparam(&ns[1], 20, 20, 'B', 1);
+        set_countparam(&ns[2], 30, 30, 'C', 1);
+        OE_TEST(deepcopy_nested_countparam_inout(enclave, &s) == OE_OK);
+        check_countparam(&ns[0], 10, 10, 'D');
+        check_countparam(&ns[1], 20, 20, 'E');
+        check_countparam(&ns[2], 30, 30, 'F');
+        free(ns[0].ptr);
+        free(ns[1].ptr);
+        free(ns[2].ptr);
+    }
+
+    {
+        CountParamNestedStruct s;
+        CountParamStruct ns[3];
+        s.num = 3;
+        s.array_of_struct = ns;
+
+        set_countparam(&ns[0], 10, 10, 'A', 1);
+        set_countparam(&ns[1], 20, 20, 'B', 1);
+        set_countparam(&ns[2], 30, 30, 'C', 1);
+        OE_TEST(deepcopy_nested_countparam_in(enclave, &s) == OE_OK);
+        free(ns[0].ptr);
+        free(ns[1].ptr);
+        free(ns[2].ptr);
     }
 
     {


### PR DESCRIPTION
Previously, deepcopy of nested in/inout parameters are not properly supported. This PR fixes the issue.

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>