### PR TITLE
BUILD_TESTS cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,15 @@ if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
        DESTINATION "${PROJECT_SOURCE_DIR}/.git/hooks")
 endif ()
 
+option(BUILD_TESTS "Build oeedger8r virtual environment tests" ON)
+
 set(CMAKE_CXX_STANDARD 11)
 
 add_subdirectory(src)
 
-enable_testing()
-add_subdirectory(test)
+if (BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(test)
+endif ()
 
 option(CODE_COVERAGE "Enable code coverage testing" OFF)


### PR DESCRIPTION
Virtual environment tests are enabled by default.
openenclave repo can use BUILD_TESTS option to disable
virtual environment tests since openenclave already
has hardware tests. Also, openenclave repo does not
run these virutal environment tests.

Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>