### PR TITLE
Enforce compilation warnings are errors on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,36 @@ option(BUILD_TESTS "Build oeedger8r virtual environment tests" ON)
 
 set(CMAKE_CXX_STANDARD 17)
 
+# Set Windows-specific compiler flags
+if (WIN32 AND MSVC)
+  # Enable warning level 3 and treat warnings as errors
+  add_compile_options(/W3 /WX)
+
+  # Enable specific warnings as errors
+  add_compile_options(
+    /we4018 # signed/unsigned mismatch
+    /we4055 # type cast from data pointer to function pointer
+    /we4146 # unary minus operator applied to unsigned type
+    /we4242 # conversion from 'type1' to 'type2', possible loss of data
+    /we4244 # conversion from 'type1' to 'type2', possible loss of data
+    /we4267 # conversion from 'size_t' to 'type', possible loss of data
+    /we4302 # truncation from 'type1' to 'type2'
+    /we4308 # negative integral constant converted to unsigned type
+    /we4509 # nonstandard extension used: function uses SEH and object has destructor
+    /we4510 # default constructor could not be generated
+    /we4532 # jump out of __finally block has undefined behavior
+    /we4533 # initialization of variable is skipped by jump instruction
+    /we4610 # object can never be instantiated - user-defined constructor required
+    /we4611 # interaction between setjmp and C++ object destruction is non-portable
+    /we4700 # uninitialized local variable used
+    /we4701 # potentially uninitialized local variable used
+    /we4703 # potentially uninitialized local pointer variable used
+    /we4789 # buffer overrun when using secure functions
+    /we4995 # function marked as #pragma deprecated
+    /we4996 # function declared deprecated
+  )
+endif ()
+
 add_subdirectory(src)
 
 if (BUILD_TESTS)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -19,8 +19,14 @@ std::map<std::string, Edl*> Parser::cache_;
 
 static bool _is_file(const std::string& path)
 {
+#ifdef _WIN32
+    FILE* f = nullptr;
+    errno_t err = fopen_s(&f, path.c_str(), "r");
+    if (err == 0 && f)
+#else
     FILE* f = fopen(path.c_str(), "r");
     if (f)
+#endif
     {
         fclose(f);
         return true;

--- a/test/comprehensive/enc/config.cpp
+++ b/test/comprehensive/enc/config.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Open Enclave SDK contributors.
 // Licensed under the MIT License.
+#include <inttypes.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include <string.h>
@@ -14,7 +15,7 @@ void configure_type(const char* type_name, type_enum_t t)
     OE_TEST(get_host_sizeof(&host_size, t) == OE_OK);
 
     printf(
-        "%s: size in host = %lu, size in enclave = %lu.",
+        "%s: size in host = %" PRIu64 ", size in enclave = %" PRIu64 ".",
         type_name,
         host_size,
         enc_size);

--- a/test/comprehensive/enc/testarray.cpp
+++ b/test/comprehensive/enc/testarray.cpp
@@ -92,10 +92,10 @@ void test_array_edl_ocalls()
     {
         uint8_t data1[IV_SIZE];
         for (uint32_t i = 0; i < IV_SIZE; ++i)
-            data1[i] = i;
+            data1[i] = static_cast<uint8_t>(i);
         uint8_t data2[EXT_IV_SIZE];
         for (uint32_t i = 0; i < EXT_IV_SIZE; ++i)
-            data2[i] = i;
+            data2[i] = static_cast<uint8_t>(i);
 
         OE_TEST(ocall_named_dims(data1, data2) == OE_OK);
     }

--- a/test/comprehensive/enc/teststring.cpp
+++ b/test/comprehensive/enc/teststring.cpp
@@ -14,7 +14,11 @@ void test_string_edl_ocalls()
     const char* str_value = "Hello, World\n";
 
     char str[50];
-    sprintf(str, "%s", str_value);
+#ifdef _WIN32
+    sprintf_s(str, sizeof(str), "%s", str_value);
+#else
+    snprintf(str, sizeof(str), "%s", str_value);
+#endif
 
     // char*
     OE_TEST(ocall_string_fun1(str) == OE_OK);
@@ -29,7 +33,11 @@ void test_string_edl_ocalls()
     OE_TEST(strcmp(str, "Goodbye\n") == 0);
 
     // Restore value.
-    sprintf(str, "%s", str_value);
+#ifdef _WIN32
+    sprintf_s(str, sizeof(str), "%s", str_value);
+#else
+    snprintf(str, sizeof(str), "%s", str_value);
+#endif
 
     // char* user check.
     OE_TEST(ocall_string_fun5(str) == OE_OK);

--- a/test/comprehensive/enc/teststruct.cpp
+++ b/test/comprehensive/enc/teststruct.cpp
@@ -387,7 +387,11 @@ MyStruct1 ecall_struct1(
 char* ecall_struct_node1(char ch, struct MyStruct_node* list)
 {
     OE_TEST(oe_is_outside_enclave(list, sizeof(*list)));
+#ifdef _WIN32
+    strncpy_s(&list->data, sizeof(list->data), &ch, sizeof(ch));
+#else
     strncpy(&list->data, &ch, sizeof(ch));
+#endif
     list->next = NULL;
 
     return &list->data;

--- a/test/comprehensive/host/testarray.cpp
+++ b/test/comprehensive/host/testarray.cpp
@@ -89,10 +89,10 @@ void test_array_edl_ecalls(oe_enclave_t* enclave)
     {
         uint8_t data1[IV_SIZE];
         for (uint32_t i = 0; i < IV_SIZE; ++i)
-            data1[i] = i;
+            data1[i] = static_cast<uint8_t>(i);
         uint8_t data2[EXT_IV_SIZE];
         for (uint32_t i = 0; i < EXT_IV_SIZE; ++i)
-            data2[i] = i;
+            data2[i] = static_cast<uint8_t>(i);
 
         OE_TEST(ecall_named_dims(enclave, data1, data2) == OE_OK);
     }

--- a/test/safe_math/enc/enc.cpp
+++ b/test/safe_math/enc/enc.cpp
@@ -44,7 +44,7 @@ int enc_deepcopy_out_overflow(CountSizeParamStruct* s)
 
 void enc_host_test()
 {
-    char* buf;
+    char* buf = (char*)malloc(10);
     int ret_val = -1;
     OE_TEST(
         host_add_overflow(&ret_val, buf, OE_UINT64_MAX) == OE_INTEGER_OVERFLOW);

--- a/test/virtual/include/openenclave/edger8r/host.h
+++ b/test/virtual/include/openenclave/edger8r/host.h
@@ -110,7 +110,7 @@ OE_INLINE void* oe_malloc(size_t size)
 
 OE_INLINE void oe_free(void* ptr)
 {
-    return free(ptr);
+    free(ptr);
 }
 
 OE_INLINE size_t oe_strlen(const char* s)


### PR DESCRIPTION
This PR enforces W3 and additional security-related warnings as errors with code fix.